### PR TITLE
Improve functionality of REPL

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -81,6 +81,14 @@ cmd s = do
 -- Options
 ------------------------------------------------------------------------------
 
+data Option = Option
+  { option_name :: String
+  , option_cmd  :: String -> Repl ()
+  , option_help :: [String]
+  }
+
+-- Type
+
 type_cmd :: String -> Repl ()
 type_cmd s = do
   env <- gets replEnv
@@ -93,6 +101,15 @@ type_cmd s = do
     minTypeAut = minimizeTypeAut typeAutDet
     res = autToType minTypeAut
   prettyRepl (" :: " ++ ppPrint res)
+
+type_option :: Option
+type_option = Option
+  { option_name = "type"
+  , option_cmd = type_cmd
+  , option_help = ["Enter a producer term and show the inferred type."]
+  }
+
+-- Show
 
 show_cmd :: String -> Repl ()
 show_cmd s = do
@@ -107,12 +124,31 @@ show_cmd s = do
                                         , ppPrint err2
                                         ]
 
+show_option :: Option
+show_option = Option
+  { option_name = "show"
+  , option_cmd = show_cmd
+  , option_help = ["Display term or type on the command line."]
+  }
+
+-- Define
+
 def_cmd :: String -> Repl ()
 def_cmd s = do
   env <- gets replEnv
   case runEnvParser declarationP env s of
     Right decl -> modifyEnvironment (insertDecl decl)
     Left err -> prettyRepl err
+
+def_option :: Option
+def_option = Option
+  { option_name = "def"
+  , option_cmd = def_cmd
+  , option_help = [ "Add a declaration to the current environment. E.g."
+                  , "\":def prd myTrue := {- Ap(x)[y] => x >> y -};\""]
+  }
+
+-- Save
 
 save_cmd :: String -> Repl ()
 save_cmd s = do
@@ -153,6 +189,16 @@ saveGraphFiles fileName aut = do
       prettyRepl (fileUri ++ currentDir </> graphDir </> fileName <.> jpg)
     False -> prettyRepl "Cannot execute command: graphviz executable not found in path."
 
+
+save_option :: Option
+save_option = Option
+  { option_name = "save"
+  , option_cmd = save_cmd
+  , option_help = ["Save generated type automata to disk as jpgs."]
+  }
+
+-- Bind
+
 bind_cmd :: String -> Repl ()
 bind_cmd s = do
   env <- gets replEnv
@@ -167,6 +213,15 @@ bind_cmd s = do
   modifyEnvironment (insertDecl (TypDecl v resType))
 
 
+bind_option :: Option
+bind_option = Option
+  { option_name = "bind"
+  , option_cmd = bind_cmd
+  , option_help = ["Infer the type of producer term, and add corresponding type declaration to environment."]
+  }
+
+-- Subsume
+
 sub_cmd :: String -> Repl ()
 sub_cmd s = do
   env <- gets replEnv
@@ -178,12 +233,31 @@ sub_cmd s = do
         -- TODO: Make this error message better
         _ -> prettyRepl "Invalid input. Either the types have non-matching polarities, they aren't polar at all or the covariance rule is violated."
 
+sub_option :: Option
+sub_option = Option
+  { option_name = "sub"
+  , option_cmd = sub_cmd
+  , option_help = [ "Check whether subsumption holds between two types. E.g."
+                  , "\":sub {+ True +} <: {+ True, False +}\""]
+  }
+
+-- Simplify
+
 simplify_cmd :: String -> Repl ()
 simplify_cmd s = do
   env <- gets replEnv
   ty <- parseRepl s typeSchemeP env
   aut <- fromRight (typeToAut ty)
   prettyRepl (autToType aut)
+
+simplify_option :: Option
+simplify_option = Option
+  { option_name = "simplify"
+  , option_cmd = simplify_cmd
+  , option_help = ["Simplify the given type."]
+  }
+
+-- Load
 
 load_cmd :: String -> Repl ()
 load_cmd s = do
@@ -198,11 +272,52 @@ load_file s = do
   modifyEnvironment ((<>) newEnv)
   prettyRepl $ "Successfully loaded: " ++ s
 
+load_option :: Option
+load_option = Option
+  { option_name = "load"
+  , option_cmd = load_cmd
+  , option_help = ["Load the given file from disk and add it to the environment."]
+  }
+
+-- Reload
+
 reload_cmd :: String -> Repl ()
 reload_cmd "" = do
   loadedFiles <- gets loadedFiles
   forM_ loadedFiles load_file
 reload_cmd _ = prettyRepl ":reload does not accept arguments"
+
+reload_option :: Option
+reload_option = Option
+  { option_name = "reload"
+  , option_cmd = reload_cmd
+  , option_help = ["Reload all loaded files from disk."]
+  }
+
+-- Help
+
+help_cmd :: String -> Repl ()
+help_cmd _ = do
+  prettyRepl "Available commands:\n"
+  forM_ all_options (\opt -> showHelp (option_name opt) (option_help opt))
+  where
+    showHelp :: String -> [String] -> Repl ()
+    showHelp name help = do
+      prettyRepl $ ":" ++ name
+      forM_ help (\help -> prettyRepl $ "    " ++ help)
+
+help_option :: Option
+help_option = Option
+  { option_name = "help"
+  , option_cmd = help_cmd
+  , option_help = ["Show all available commands."]
+  }
+
+-- All Options
+
+all_options :: [Option]
+all_options = [ type_option, show_option, help_option, def_option, save_option
+              , sub_option, bind_option, simplify_option, load_option, reload_option]
 
 ------------------------------------------------------------------------------
 -- Repl Configuration
@@ -221,20 +336,16 @@ ini = do
 final :: Repl ExitDecision
 final = prettyRepl "Goodbye!" >> return Exit
 
+repl_banner :: a -> Repl String
+repl_banner _ = do
+  loadedFiles <- gets loadedFiles
+  pure (unwords loadedFiles ++ ">")
+
 opts :: ReplOpts ReplInner
 opts = ReplOpts
-  { banner           = const (pure ">>> ")
+  { banner           = repl_banner
   , command          = cmd
-  , options          = [ ("type", type_cmd)
-                       , ("show", show_cmd)
-                       , ("def", def_cmd)
-                       , ("save", save_cmd)
-                       , ("load", load_cmd)
-                       , ("bind", bind_cmd)
-                       , ("sub", sub_cmd)
-                       , ("reload", reload_cmd)
-                       , ("simplify", simplify_cmd)
-                       ]
+  , options          = (\opt -> (option_name opt, option_cmd opt)) <$> all_options
   , prefix           = Just ':'
   , multilineCommand = Nothing
   , tabComplete      = Word0 completer


### PR DESCRIPTION
- The Repl now stores a list of loaded files (initially just "prg.txt"), to which additional files can be added with "load". "reload" now reloads the content of all these files from disk.
- Prompt now shows list of loaded files, e.g.
```
prg.txt>:load MyFile.txt
Successfully loaded: MyFile.txt
prg.txt MyFile.txt>
```
- There is a `:help` command which lists all commands with a little help text. In order to generate this command automatically, every option/command is wrapped in a "Option" record.
```
prg.txt >:help
Available commands:

:type
    Enter a producer term and show the inferred type.
:show
    Display term or type on the command line.
:help
    Show all available commands.
:def
    Add a declaration to the current environment. E.g.
    ":def prd myTrue := {- Ap(x)[y] => x >> y -};"
:save
    Save generated type automata to disk as jpgs.
:sub
    Check whether subsumption holds between two types. E.g.
    ":sub {+ True +} <: {+ True, False +}"
:bind
    Infer the type of producer term, and add corresponding type declaration to environment.
:simplify
    Simplify the given type.
:load
    Load the given file from disk and add it to the environment.
:reload
    Reload all loaded files from disk.
```