### PR TITLE
Change nub to ordNub

### DIFF
--- a/src/Syntax/Terms.hs
+++ b/src/Syntax/Terms.hs
@@ -10,7 +10,7 @@ type XtorName = String -- start with uppercase
 type FreeVarName = String -- start with lowercase
 type TypeIdentifierName = String -- start with uppercase
 
-data DataOrCodata = Data | Codata deriving (Eq,Show)
+data DataOrCodata = Data | Codata deriving (Eq,Show,Ord)
 showDataOrCodata :: DataOrCodata -> String
 showDataOrCodata Data = "+"
 showDataOrCodata Codata = "-"

--- a/src/Syntax/TypeGraph.hs
+++ b/src/Syntax/TypeGraph.hs
@@ -6,8 +6,7 @@ import Data.Graph.Inductive.PatriciaTree
 import Data.Set (Set)
 import Data.Bifunctor (bimap)
 import Data.Functor.Identity
---import Data.Containers.ListUtils (nubOrd)
-import qualified Data.List (nub)
+import Data.Containers.ListUtils (nubOrd)
 import Syntax.Types
 import Syntax.Terms
 
@@ -31,10 +30,7 @@ type NodeLabel = (Polarity, HeadCons)
 
 data EdgeLabel
   = EdgeSymbol DataOrCodata XtorName PrdOrCns Int
-  deriving (Eq,Show)
-
-instance Ord EdgeLabel where
-  compare (EdgeSymbol _ _ _ x) (EdgeSymbol _ _ _ y) = compare x y
+  deriving (Eq,Show, Ord)
 
 type FlowEdge = (Node, Node)
 
@@ -61,7 +57,7 @@ class Nubable f where
 instance Nubable Identity where
   nub = id
 instance Nubable [] where
-  nub = Data.List.nub
+  nub = nubOrd
 
 forgetDet :: TypeAutDet -> TypeAut
 forgetDet aut@TypeAut{..} = aut { ta_starts = [runIdentity ta_starts] }


### PR DESCRIPTION
Fixes #6 Fixes #9 

This shouldn't be the thing that fixes it, but it does. The difference between `nub` and `ordNub` are that OrdNub has an Ord constraint instead of a Eq constraint, and that it runs in n*log n instead of n^2 time.

I think the problem is that the underlying Ord instance for Edge Label is broken / doesn't work with ordNub.

See:
```
instance Ord EdgeLabel where
  compare (EdgeSymbol _ _ _ x) (EdgeSymbol _ _ _ y) = compare x y
```