### PR TITLE
Don't crash the Repl if an error occurs

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -340,7 +340,7 @@ opts :: ReplOpts ReplInner
 opts = ReplOpts
   { banner           = repl_banner
   , command          = cmd
-  , options          = (\opt -> (option_name opt, option_cmd opt)) <$> all_options
+  , options          = (\opt -> (option_name opt, \s -> dontCrash ((option_cmd opt) s))) <$> all_options
   , prefix           = Just ':'
   , multilineCommand = Nothing
   , tabComplete      = Word0 completer


### PR DESCRIPTION
As the title says:

Previous behaviour:
```console
bash@david:(dont-crash):~/GitRepos/algebraic-subtyping-implementation$ stack run
Algebraic subtyping for structural Ouroboro.
Press Ctrl+D to exit.
Successfully loaded: prg.txt
prg.txt>:load foo
simple-exe: foo: openFile: does not exist (No such file or directory)
bash@david:(dont-crash):~/GitRepos/algebraic-subtyping-implementation$ 
```

New behaviour:

```console
bash@david:(dont-crash):~/GitRepos/algebraic-subtyping-implementation$ stack run
Algebraic subtyping for structural Ouroboro.
Press Ctrl+D to exit.
Successfully loaded: prg.txt
prg.txt>:load foo
foo: openFile: does not exist (No such file or directory)
prg.txt>
```