### PR TITLE
Refactor parser

### DIFF
--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -23,6 +23,13 @@ newtype TypeName = MkTypeName { unTypeName :: String } deriving (Eq, Show, Ord)
 
 data SimpleTarget = Simple | Target deriving (Eq, Ord, Show)
 
+-- | Singleton Type for SimpleTarget
+data SimpleTargetRep st where
+  SimpleRep :: SimpleTargetRep Simple
+  TargetRep :: SimpleTargetRep Target
+deriving instance Show (SimpleTargetRep st)
+
+
 data DataCodata = Data | Codata deriving (Eq, Ord, Show)
 
 data UnionInter = Union | Inter deriving (Eq, Show, Ord)


### PR DESCRIPTION
- Remove the old "TypeParser" type. This is necessary to interleave parsing of types and terms. (For example, when adding local type annotations.)
- Use the unification of SimpleTypes and TargetTypes to unify the type parsers.