### PR TITLE
Add choice between cbv and cbn evaluation

### DIFF
--- a/src/Eval/Eval.hs
+++ b/src/Eval/Eval.hs
@@ -1,22 +1,33 @@
-module Eval.Eval (eval, evalSteps) where
+module Eval.Eval
+  ( EvalOrder(..)
+  , runEval
+  , eval
+  , evalSteps
+  ) where
 
 import Prettyprinter
-
+import Control.Monad.Reader
+import Control.Monad.Except
 import Data.List (find)
 import Syntax.Terms
 import Eval.Substitution
 import Utils
 import Pretty
 
-type EvalM a = Either Error a
+data EvalOrder = CBV | CBN
+
+type EvalM a = (ReaderT EvalOrder (Except Error)) a
+
+runEval :: EvalM a -> EvalOrder -> Either Error a
+runEval e evalorder = runExcept (runReaderT e evalorder)
 
 lookupCase :: XtorName -> [Case a] -> EvalM (Case a)
 lookupCase xt cases = case find (\MkCase { case_name } -> xt == case_name) cases of
-  Just pmcase -> Right pmcase
-  Nothing -> Left $ EvalError $ unlines ["Error during evaluation. The xtor: "
-                                        , unXtorName xt
-                                        , "doesn't occur in match."
-                                        ]
+  Just pmcase -> return pmcase
+  Nothing -> throwError $ EvalError $ unlines ["Error during evaluation. The xtor: "
+                                              , unXtorName xt
+                                              , "doesn't occur in match."
+                                              ]
 
 lengthXtorArgs :: XtorArgs a -> Twice Int
 lengthXtorArgs MkXtorArgs { prdArgs, cnsArgs } = Twice (length prdArgs) (length cnsArgs)
@@ -25,8 +36,8 @@ checkArgs :: Pretty a => Command a -> Twice [a] -> XtorArgs a -> EvalM ()
 checkArgs cmd argTypes args =
   if fmap length argTypes == lengthXtorArgs args
   then return ()
-  else Left $ EvalError ("Error during evaluation of \"" ++ ppPrint cmd ++
-                           "\"\nArgument lengths don't coincide.")
+  else throwError $ EvalError ("Error during evaluation of \"" ++ ppPrint cmd ++
+                               "\"\nArgument lengths don't coincide.")
 
 -- | Returns Nothing if command was in normal form, Just cmd' if cmd reduces to cmd' in one step
 evalOneStep :: Pretty a => Command a -> EvalM (Maybe (Command a))
@@ -40,18 +51,23 @@ evalOneStep cmd@(Apply (Match PrdRep _ cases) (XtorCall CnsRep xt args)) = do
   (MkCase _ argTypes cmd') <- lookupCase xt cases
   checkArgs cmd argTypes args
   return (Just (commandOpening args cmd')) --reduction is just opening
+evalOneStep (Apply prd@(MuAbs PrdRep _ cmd) cns@(MuAbs CnsRep _ cmd')) = do
+  evalOrder <- ask
+  case evalOrder of
+    CBV -> return (Just (commandOpeningSingle CnsRep cns cmd))
+    CBN -> return (Just (commandOpeningSingle PrdRep prd cmd'))
 evalOneStep (Apply (MuAbs PrdRep _ cmd) cns) = return (Just (commandOpeningSingle CnsRep cns cmd))
 evalOneStep (Apply prd (MuAbs CnsRep _ cmd)) = return (Just (commandOpeningSingle PrdRep prd cmd))
 -- Error handling
-evalOneStep cmd@(Apply _ _) = Left $ EvalError ("Error during evaluation of \"" ++ ppPrint cmd ++
-                                          "\"\n Free variable encountered!")
+evalOneStep cmd@(Apply _ _) = throwError $ EvalError ("Error during evaluation of \"" ++ ppPrint cmd ++
+                                                      "\"\n Free variable encountered!")
 
 -- | Return just thef final evaluation result
 eval :: Pretty a => Command a -> EvalM (Command a)
 eval cmd = do
   cmd' <- evalOneStep cmd
   case cmd' of
-    Nothing -> Right cmd
+    Nothing -> return cmd
     Just cmd' -> eval cmd'
 
 -- | Return all intermediate evaluation results
@@ -62,6 +78,6 @@ evalSteps cmd = evalSteps' [cmd] cmd
     evalSteps' cmds cmd = do
       cmd' <- evalOneStep cmd
       case cmd' of
-        Nothing -> Right cmds
+        Nothing -> return cmds
         Just cmd' -> evalSteps' (cmds ++ [cmd']) cmd'
 


### PR DESCRIPTION
Since this is so easy to implement, I added the choice between CBV and CBN evaluation to the Repl.

Example:

```
bash@david:(eval-orders):~/GitRepos/algebraic-subtyping-implementation$ stack run
Algebraic subtyping for structural Ouroboro.
Press Ctrl+D to exit.
Successfully loaded: prg.txt
prg.txt>mu x. Print(2) >> mu* y.Print(4)
Print 'S('S('Z))
prg.txt>:set cbn
prg.txt>mu x. Print(2) >> mu* y.Print(4)
Print 'S('S('S('S('Z))))
prg.txt>:set cbv
prg.txt>mu x. Print(2) >> mu* y.Print(4)
Print 'S('S('Z))
prg.txt>
```