### PR TITLE
Allow recursive declarations

### DIFF
--- a/examples/recursiveExample.ds
+++ b/examples/recursiveExample.ds
@@ -1,10 +1,10 @@
-# prd addS := comatch { 'Ap(x,y)[k] =>
-#                        x
-#                        >>
-#                        match { 'Zero    => y >> k
-#                              , 'Succ(z) => addS >> 'Ap(z,'Succ(y))[k]
-#                              }
-#                    };
+prd addS := comatch { 'Ap(x,y)[k] =>
+                       x
+                       >>
+                       match { 'Zero    => y >> k
+                             , 'Succ(z) => addS >> 'Ap(z,'Succ(y))[k]
+                             }
+                   };
 
 def addA := comatch { 'Ap(x,y) => match x with { 'Zero => y
                                                , 'Succ(z) => addA.'Ap(z, 'Succ(y))

--- a/src/TypeInference/GenerateConstraints/ATerms.hs
+++ b/src/TypeInference/GenerateConstraints/ATerms.hs
@@ -64,6 +64,9 @@ genConstraintsATermCocase (MkACase { acase_name, acase_args, acase_term }) = do
   let sig = MkXtorSig acase_name (MkTypArgs argtsNeg [retType])
   return (MkACase acase_name argtsPos acase_term', sig)
 
+---------------------------------------------------------------------------------------------
+-- Asymmetric Terms with recursive binding
+---------------------------------------------------------------------------------------------
 
 genConstraintsATermRecursive :: FreeVarName -> ATerm () -> GenM (ATerm (Typ Pos), Typ Pos)
 genConstraintsATermRecursive fv tm = do

--- a/src/TypeInference/InferProgram.hs
+++ b/src/TypeInference/InferProgram.hs
@@ -23,9 +23,9 @@ import TypeInference.SolveConstraints (solveConstraints)
 -- Symmetric Terms and Commands
 ------------------------------------------------------------------------------
 
-inferSTerm :: PrdCnsRep pc -> STerm pc () -> Environment -> Either Error (TypeScheme (PrdCnsToPol pc))
-inferSTerm rep tm env = do
-  ((_,ty), constraintSet) <- runGenM env (genConstraintsSTerm tm)
+inferSTerm :: FreeVarName -> PrdCnsRep pc -> STerm pc () -> Environment -> Either Error (TypeScheme (PrdCnsToPol pc))
+inferSTerm fv rep tm env = do
+  ((_,ty), constraintSet) <- runGenM env (genConstraintsSTermRecursive fv rep tm)
   solverState <- solveConstraints constraintSet
   typeAut <- solverStateToTypeAut solverState (prdCnsToPol rep) ty
   let typeAutDet = determinize typeAut
@@ -57,10 +57,10 @@ inferATerm v tm env = do
 
 insertDecl :: Declaration () -> Environment -> Either LocatedError Environment
 insertDecl (PrdDecl loc v t)  env@Environment { prdEnv }  = do
-  ty <- first (Located loc) $ inferSTerm PrdRep t env
+  ty <- first (Located loc) $ inferSTerm v PrdRep t env
   return $ env { prdEnv  = M.insert v (t,ty) prdEnv }
 insertDecl (CnsDecl loc v t)  env@Environment { cnsEnv }  = do
-  ty <- first (Located loc) $ inferSTerm CnsRep t env
+  ty <- first (Located loc) $ inferSTerm v CnsRep t env
   return $ env { cnsEnv  = M.insert v (t,ty) cnsEnv }
 insertDecl (CmdDecl loc v t)  env@Environment { cmdEnv }  = do
   first (Located loc) $ checkCmd t env


### PR DESCRIPTION
There are not yet enough test cases to show that the implementation is bugfree, but typeinference for the simple examples in `examples/recursiveExamples.ds` work correctly. I.e. the correct types are inferred:

```
>:load examples/recursiveExample.ds 
Producers:
addS : forall t0. { 'Ap(rec r0.< 'Succ(r0) | 'Zero >,t0)[rec r2.(t0 \/ < 'Succ(r2) >)] }

Consumers:

Commands

Definitions:
addA : forall t0. { 'Ap(rec r0.< 'Succ(r0) | 'Zero >,t0)[rec r2.(t0 \/ < 'Succ(r2) >)] }

```