### PR TITLE
Subst predicate

### DIFF
--- a/dualsub.cabal
+++ b/dualsub.cabal
@@ -115,6 +115,7 @@ test-suite dualsub-test
   main-is: TestRunner.hs
   other-modules:
       Eval.FocusingSpec
+    , Eval.SubstSpec
     , Translate.TranslateExamplesSpec
     , TypeInference.StaticExamplesSpec
     , TypeInference.FileExamplesSpec

--- a/test/Eval/FocusingSpec.hs
+++ b/test/Eval/FocusingSpec.hs
@@ -15,15 +15,13 @@ evalFocusing evalOrder cmd cmdRes = do
   case runInteractiveParser commandP cmd of
     Left err -> it "Could not parse" $ expectationFailure (ppPrint err)
     Right (cmd',_) -> do
-      let Left _ = runInteractiveParser commandP cmd
       let Right (cmdRes',_) = runInteractiveParser commandP cmdRes
-      let Left _ = runInteractiveParser commandP cmdRes
       prgEnv <- runIO $ getEnvironment "examples/prg.ds"
       case prgEnv of
         Left err -> it "Could not load prg.ds" $ expectationFailure (ppPrint err)
         Right prgEnv -> do
           case runEval (eval $ bimap (const ()) id cmd') evalOrder prgEnv of
-            Left err -> it "Could not load evaluate" $ expectationFailure (ppPrint err)
+            Left err -> it "Could not evaluate" $ expectationFailure (ppPrint err)
             Right b -> 
               it (cmd ++  " evaluates to: " ++ cmdRes) $ do
               b `shouldBe` (bimap (const ()) id cmdRes')

--- a/test/Eval/SubstSpec.hs
+++ b/test/Eval/SubstSpec.hs
@@ -1,0 +1,47 @@
+module Eval.SubstSpec ( spec )  where
+
+import Test.Hspec
+
+import Parser.Parser
+import Pretty.Errors ()
+import Syntax.STerms
+import Eval.STerms (areAllSubst)
+import Eval.Eval
+import Control.Monad (forM_)
+
+
+substCtorExample :: EvalOrder -> String -> Spec
+substCtorExample order termS = do
+  it (termS ++  " can't be substituted.") $ do
+      let Right (term,_) = runInteractiveParser (stermP PrdRep) termS
+      case term of
+        XtorCall _ PrdRep _ args -> (areAllSubst order args) `shouldBe` False
+        _ -> error $ termS ++ "is not a Ctor."
+
+cbvExamples :: [(EvalOrder,String)]
+cbvExamples = 
+    -- CBV examples
+    (\s -> (CBV, s)) <$>
+    [
+    "C(mu x. 42 >> mu y. Print(y))[mu y. Print(y)]"
+    , "C2(C(mu x. 42 >> mu y. Print(y))[mu y. Print(y)])"
+    , "C(42)[D(mu x. Print(x))]"
+    , "C( C(42)[D()[D2(mu x.Print(x))[]]])"
+    , "C(42)[D()[D()[C(mu x. Print(x))[]]]]"
+    ]
+
+cbnExamples :: [(EvalOrder,String)]
+cbnExamples = 
+    -- CBN examples
+    (\s -> (CBN, s)) <$>
+    [
+    "C('True)[mu x.Print(x)]"
+    , "C('True)[D()[mu x. Print(x)]]"
+    , "C(C(2)[mu x.Print(x)])[print]"
+    , "C(C(2)[D()[mu x.Print(x)]])[print]"
+    , "C(2)[C(2)[D(0)[mu x.Print(x)]]]"
+    ]
+
+
+spec :: Spec
+spec = forM_ (cbvExamples ++ cbnExamples) $ uncurry $ substCtorExample


### PR DESCRIPTION
Implement _substitute_ predicate with `areAllSubst`, `isSubstPrd`, `isSubstCns`.
Additional tests in `SubstSpec.hs`.