### PR TITLE
differentiate between structural and nominal Nat literals

### DIFF
--- a/examples/prg.ds
+++ b/examples/prg.ds
@@ -496,7 +496,7 @@ prd mltNominal := comatch { 'Ap(n,m)[k] => fix >> 'Ap(comatch { 'Ap(alpha)[k] =>
 prd expNominal := comatch { 'Ap(n,m)[k] => fix >> 'Ap(comatch { 'Ap(alpha)[k] => comatch { 'Ap(m)[k] => m >> match { Z => S(Z) >> k, S(p) => alpha >> 'Ap(p)[mu w. mltNominal >> 'Ap(n,w)[k]] } } >> k })['Ap(m)[k]] };
 prd subSafeNominal := comatch { 'Ap(n,m)[k] => fix >> 'Ap(comatch { 'Ap(alpha)[k] => comatch { 'Ap(n)[k] => comatch { 'Ap(m)[k] => m >> match { Z => n >> k, S(mp) => n >> match { Z => n >> k, S(np) => alpha >> 'Ap(np)['Ap(mp)[k]] }}} >> k } >> k })['Ap(n)['Ap(m)[k]]]};
 
-cmd exampleCommand1 := Print(2);
-cmd exampleCommand2 := mu x.Print(2) >> mu y. Print(4);
+cmd exampleCommand1 := Print('2);
+cmd exampleCommand2 := mu x.Print('2) >> mu y. Print('4);
 
 def newStylePredTwo := (comatch { 'Ap(x) => match x with { 'Z() => 'Z(), 'S(x) => x }}.'Ap('S('S('S('Z())))));

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -41,6 +41,8 @@ module Parser.Lexer
   , braces
   , dbraces
   , argListP
+
+  , checkTick
   ) where
 
 import Text.Megaparsec hiding (State)
@@ -116,17 +118,16 @@ freeVarName = do
   checkReserved name
   return (name, pos)
 
+checkTick :: NominalStructural -> Parser ()
+checkTick Nominal = return ()
+checkTick Structural = () <$ tick
 
 xtorName :: NominalStructural -> Parser (XtorName, SourcePos)
-xtorName Structural = do
-  _ <- tick
+xtorName ns = do
+  () <- checkTick ns
   (name, pos) <- lexeme $ (:) <$> upperChar <*> many alphaNumChar
   checkReserved name
-  return (MkXtorName Structural name, pos) -- Saved without tick!
-xtorName Nominal = do
-  (name, pos) <- lexeme $ (:) <$> upperChar <*> many alphaNumChar
-  checkReserved name
-  return (MkXtorName Nominal name, pos)
+  return (MkXtorName ns name, pos)
 
 typeNameP :: Parser (TypeName, SourcePos)
 typeNameP = do


### PR DESCRIPTION
Change (structural) Nat literals to '42 etc and add parser for nominal
literals, which don't use a tick