### PR TITLE
Cache hover info

### DIFF
--- a/app/LSP/Definition.hs
+++ b/app/LSP/Definition.hs
@@ -3,6 +3,7 @@ module LSP.Definition where
 import Control.Monad.IO.Class ( MonadIO)
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 
+import Data.Map (Map)
 import Data.IORef
 import Language.LSP.Server
 import Language.LSP.Types
@@ -11,7 +12,7 @@ import qualified Data.Text as T
 -- LSPMonad and Utility Functions
 ---------------------------------------------------------------------------------
 
-type HoverCache = Position -> Maybe Hover
+type HoverCache = Map Uri (Position -> Maybe Hover)
 data LSPConfig = MkLSPConfig (IORef HoverCache)
 
 newtype LSPMonad a = MkLSPMonad { unLSPMonad :: (LspT LSPConfig IO a) }

--- a/app/LSP/LSP.hs
+++ b/app/LSP/LSP.hs
@@ -66,7 +66,7 @@ serverOptions = Options
 
 definition :: IO (ServerDefinition LSPConfig)
 definition = do
-  initialCache <- newIORef (const Nothing)
+  initialCache <- newIORef M.empty 
   return ServerDefinition
     { defaultConfig = MkLSPConfig initialCache
     , onConfigurationChange = \config _ -> pure config
@@ -89,7 +89,7 @@ runLSP :: IO ()
 runLSP = do
   setupLogger (Just "lsplog.txt") ["lspserver"] DEBUG
   debugM "lspserver" $ "Starting LSP Server"
-  initalDefinition <- definition
+  initialDefinition <- definition
   errCode <- runServer initialDefinition
   case errCode of
     0 -> exitSuccess
@@ -206,6 +206,6 @@ publishErrors uri = do
           sendLocatedError (toNormalizedUri uri) err
           -- sendError "Typeinference error!"
         Right env -> do
-          updateHoverCache env
+          updateHoverCache uri env
           sendInfo $ "No errors in " <> T.pack fp <> "!"
 


### PR DESCRIPTION
Use an IORef to cache the hoverinfo. Avoids typechecking on every hover request.