### PR TITLE
Change ErrorType of Parser to Error earlier in pipeline

### DIFF
--- a/app/Compile.hs
+++ b/app/Compile.hs
@@ -1,10 +1,10 @@
 module Compile (runCompile) where
 
+import Control.Monad.Except (runExcept)
 import Control.Monad.IO.Class (liftIO)
 import Data.Map qualified as M
 import Data.Text.IO qualified as T
 import System.IO.Error (tryIOError)
-import Text.Megaparsec (errorBundlePretty)
 
 import Eval.Eval (eval)
 import Parser.Parser (runFileParser)
@@ -29,9 +29,9 @@ runCompile fp = do
     (Left _) -> putStrLn $ "File with name " ++ fp ++ " does not exist."
     (Right file) -> do
         -- Parse file
-        let parsedFile = runFileParser fp programP file
+        let parsedFile = runExcept (runFileParser fp programP file)
         case parsedFile of
-            (Left err) -> ppPrintIO (errorBundlePretty err)
+            (Left err) -> ppPrintIO err
             (Right prog) -> do
                 -- Infer program
                 inferredProg <- inferProgramIO driverState prog

--- a/app/LSP/MegaparsecToLSP.hs
+++ b/app/LSP/MegaparsecToLSP.hs
@@ -1,22 +1,12 @@
 module LSP.MegaparsecToLSP where
 
-import Data.Text (Text)
-import Data.Text qualified as T
-import Data.Void (Void)
-import Data.List.NonEmpty qualified as NE
 import Text.Megaparsec
-    ( PosState(pstateSourcePos),
-      SourcePos(SourcePos),
-      errorOffset,
-      ParseErrorBundle(..),
-      TraversableStream(reachOffset),
-      unPos, ParseError, parseErrorTextPretty )
+    ( SourcePos(SourcePos), unPos )
 import Utils ( Loc(..) )
 import Language.LSP.Types
     ( Position(..),
-      Range(..),
-      Diagnostic(..),
-      DiagnosticSeverity(DsError) )
+      Range(..)
+    )
 
 -- | Transform a Megaparsec "SourcePos" to a LSP "Position".
 -- Megaparsec and LSP's numbering conventions don't align!
@@ -30,34 +20,6 @@ locToRange (Loc startPos endPos) =
   Range { _start = posToPosition startPos
         , _end   = posToPosition endPos
         }
-
--- | Compute a position from a given offset and the PosState of the
--- beginning of the file.
-getPosFromOffset :: Int ->  PosState Text -> Position
-getPosFromOffset offset ps =
-  let
-    ps' = snd (reachOffset offset ps)
-  in
-    posToPosition (pstateSourcePos ps')
-
-parseErrorToDiag :: PosState Text -> ParseError Text Void -> Diagnostic 
-parseErrorToDiag posState err = do
-    let offset = errorOffset err
-    let pos = getPosFromOffset offset posState
-    let rng = Range pos pos
-    let msg = T.pack $ parseErrorTextPretty err
-    Diagnostic { _range = rng
-               , _severity = Just DsError
-               , _code = Nothing
-               , _source = Nothing
-               , _message = msg
-               , _tags = Nothing
-               , _relatedInformation = Nothing
-               }
-
-parseErrorBundleToDiag :: ParseErrorBundle Text Void -> [Diagnostic]
-parseErrorBundleToDiag ParseErrorBundle { bundlePosState, bundleErrors } =
-    NE.toList  $ parseErrorToDiag bundlePosState <$> bundleErrors
 
 lookupPos :: Position -> Loc -> Bool 
 lookupPos (Position l _) (Loc begin end) =

--- a/app/Repl/Options/Let.hs
+++ b/app/Repl/Options/Let.hs
@@ -1,10 +1,9 @@
 module Repl.Options.Let (letOption) where
 
+import Control.Monad.Except (runExcept)
 import Control.Monad.State ( gets, MonadIO(liftIO) )
-import Data.Bifunctor ( Bifunctor(first) )
 import Data.Text (Text)
 import Data.Text qualified as T
-import Text.Megaparsec ( errorBundlePretty )
 
 import Parser.Parser ( runInteractiveParser, declarationP )
 import Repl.Repl
@@ -19,7 +18,7 @@ import Driver.Driver
 
 letCmd :: Text -> Repl ()
 letCmd s = do
-  decl <- fromRight (first (T.pack . errorBundlePretty) (runInteractiveParser declarationP s))
+  decl <- fromRight (runExcept (runInteractiveParser declarationP s))
   oldEnv <- gets replEnv
   opts <- gets typeInfOpts
   let ds = DriverState opts oldEnv

--- a/app/Repl/Repl.hs
+++ b/app/Repl/Repl.hs
@@ -1,8 +1,8 @@
 module Repl.Repl  where
 
+import Control.Monad.Except (runExcept)
 import Control.Monad.State
     ( gets, forM_, StateT, MonadIO(liftIO), modify )
-import Data.Bifunctor (first)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
@@ -27,7 +27,6 @@ import Driver.Driver
 import Translate.Desugar
 import Translate.Focusing
 import Utils (trimStr, defaultLoc)
-import Text.Megaparsec.Error (errorBundlePretty)
 
 ------------------------------------------------------------------------------
 -- Internal State of the Repl
@@ -77,12 +76,12 @@ fromRight (Left err) = prettyRepl err >> abort
 
 parseInteractive :: Parser a -> Text -> Repl a
 parseInteractive p s = do
-  fromRight (first (T.pack . errorBundlePretty) (runInteractiveParser p s))
+  fromRight (runExcept (runInteractiveParser p s))
 
 parseFile :: FilePath -> Parser a -> Repl a
 parseFile fp p = do
   s <- safeRead fp
-  fromRight (first (T.pack . errorBundlePretty) (runFileParser fp p s))
+  fromRight (runExcept (runFileParser fp p s))
 
 safeRead :: FilePath -> Repl Text
 safeRead file =  do

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -14,7 +14,6 @@ import Control.Monad.Except
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Text.Megaparsec hiding (Pos)
 
 import Driver.Definition
 import Errors
@@ -186,15 +185,12 @@ inferProgramFromDisk :: FilePath
                      -> DriverM (Environment Inferred, Program Inferred)
 inferProgramFromDisk fp = do
   file <- liftIO $ T.readFile fp
-  let parsed = runFileParser fp programP file
-  case parsed of
-    Left err -> throwOtherError [T.pack (errorBundlePretty err)]
-    Right decls -> do
-      -- Use inference options of parent? Probably not?
-      x <- liftIO $ inferProgramIO  (DriverState defaultInferenceOptions { infOptsLibPath = ["examples"] } mempty) decls
-      case x of
-        Left err -> throwError err
-        Right env -> return env
+  decls <- runFileParser fp programP file
+  -- Use inference options of parent? Probably not?
+  x <- liftIO $ inferProgramIO  (DriverState defaultInferenceOptions { infOptsLibPath = ["examples"] } mempty) decls
+  case x of
+     Left err -> throwError err
+     Right env -> return env
 
 inferProgram :: [CST.Declaration]
              -> DriverM (Program Inferred)

--- a/src/Pretty/Errors.hs
+++ b/src/Pretty/Errors.hs
@@ -3,6 +3,7 @@ module Pretty.Errors (printLocatedError) where
 import Control.Monad (forM_)
 import Control.Monad.IO.Class
 import Data.Text.IO qualified as T
+import Data.List.NonEmpty qualified as NE
 import Prettyprinter
 import Text.Megaparsec.Pos
 
@@ -25,6 +26,9 @@ instance PrettyAnn PrdCns where
   prettyAnn Prd = "Prd"
   prettyAnn Cns = "Cns"
 
+instance PrettyAnn ParserError where
+  prettyAnn (MkParserError loc txt) = prettyAnn loc <+> prettyAnn txt
+
 instance PrettyAnn LoweringError where
   prettyAnn MissingVarsInTypeScheme               = "Missing declaration of type variable"
   prettyAnn TopInPosPolarity                      = "Cannot use `Top` in positive polarity"
@@ -45,7 +49,7 @@ instance PrettyAnn LoweringError where
                                                    ]
 
 instance PrettyAnn Error where
-  prettyAnn (ParseError loc err)            = prettyMaybeLoc loc <> "Parsing error:" <+> pretty err
+  prettyAnn (ParserErrorBundle errs)        = vsep (NE.toList (prettyAnn <$> errs))
   prettyAnn (EvalError loc err)             = prettyMaybeLoc loc <>"Evaluation error:" <+> pretty err
   prettyAnn (GenConstraintsError loc err)   = prettyMaybeLoc loc <> "Constraint generation error:" <+> pretty err
   prettyAnn (SolveConstraintsError loc err) = prettyMaybeLoc loc <> "Constraint solving error:" <+> pretty err

--- a/src/Syntax/Lowering/Program.hs
+++ b/src/Syntax/Lowering/Program.hs
@@ -3,9 +3,7 @@ module Syntax.Lowering.Program (lowerProgram, lowerDecl) where
 import Control.Monad.Except (throwError)
 import Control.Monad.State
 import Data.Map qualified as M
-import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import Text.Megaparsec ( errorBundlePretty )
 
 import Errors
 import Syntax.Lowering.Terms (lowerTerm, lowerCommand)
@@ -128,7 +126,5 @@ lowerProgramFromDisk :: FilePath
                      -> DriverM (Environment Inferred)
 lowerProgramFromDisk fp = do
   file <- liftIO $ T.readFile fp
-  let parsed = runFileParser fp programP file
-  case parsed of
-    Left err -> throwOtherError [T.pack (errorBundlePretty err)]
-    Right decls -> pure $ createSymbolTable decls
+  decls <- runFileParser fp programP file
+  pure $ createSymbolTable decls

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -1,9 +1,8 @@
 module TestUtils where
 
-import Data.Text qualified as T
+import Control.Monad.Except
 import Data.Text.IO qualified as T
 import System.Directory (listDirectory)
-import Text.Megaparsec (errorBundlePretty)
 
 import Errors
 import Parser.Parser
@@ -26,8 +25,8 @@ getAvailableExamples fp = do
 getParsedDeclarations :: FilePath -> IO (Either Error CST.Program)
 getParsedDeclarations fp = do
   s <- T.readFile fp
-  case runFileParser fp programP s of
-    Left err -> pure (Left (ParseError Nothing (T.pack (errorBundlePretty err))))
+  case runExcept (runFileParser fp programP s) of
+    Left err -> pure (Left err)
     Right prog -> pure (pure prog)
 
 getRenamedDeclarations :: FilePath -> InferenceOptions -> IO (Either Error (Program Parsed))


### PR DESCRIPTION
This is one commit cherry-picked from #288 (which is still WIP) which can be reviewed independently.
The basic idea is to perform the translation of Errors generated by Megaparsec to our internal Error type earlier in the pipeline. I.e. directly in the `runFileParser` function of the parser. 