### PR TITLE
Replace TySet by TyUnion, TyInter, TyTop and TyBot

### DIFF
--- a/app/LSP/HoverHandler.hs
+++ b/app/LSP/HoverHandler.hs
@@ -345,13 +345,34 @@ instance ToHoverMap (Typ pol) where
                       ]
     in
       mkHoverMap loc msg
-  toHoverMap (TySet loc rep _knd args) =
+  toHoverMap (TyTop loc _knd) =
     let
-      msg = T.unlines [ "#### Set type"
-                      , "- Polarity: " <> prettyPolRep rep
+      msg = T.unlines [ "#### Top type"
+                      , "- Polarity: " <> prettyPolRep NegRep
                       ]
     in
-      M.unions ((mkHoverMap loc msg) : (toHoverMap <$> args))
+      mkHoverMap loc msg
+  toHoverMap (TyBot loc _knd) =
+    let
+      msg = T.unlines [ "#### Bot type"
+                      , "- Polarity: " <> prettyPolRep PosRep
+                      ]
+    in
+      mkHoverMap loc msg
+  toHoverMap (TyUnion loc _knd ty1 ty2) =
+    let
+      msg = T.unlines [ "#### Union type"
+                      , "- Polarity: " <> prettyPolRep PosRep
+                      ]
+    in
+      M.unions [mkHoverMap loc msg, toHoverMap ty1, toHoverMap ty2]
+  toHoverMap (TyInter loc _knd ty1 ty2) =
+    let
+      msg = T.unlines [ "#### Intersection type"
+                      , "- Polarity: " <> prettyPolRep NegRep
+                      ]
+    in
+      M.unions [mkHoverMap loc msg, toHoverMap ty1, toHoverMap ty2]
   toHoverMap (TyRec loc rep _var ty) =
     let
       msg = T.unlines [ "#### Recursive type"

--- a/src/Pretty/Types.hs
+++ b/src/Pretty/Types.hs
@@ -69,12 +69,10 @@ instance PrettyAnn (RST.Typ pol) where
   -- Sugared types
   prettyAnn (resugarType -> Just (ty1, binOp, ty2)) = parens (ty1 <+> prettyAnn binOp <+> ty2)
   -- Lattice types
-  prettyAnn (RST.TySet _ PosRep _ [])  = botSym
-  prettyAnn (RST.TySet _ PosRep _ [t]) = prettyAnn t
-  prettyAnn (RST.TySet _ PosRep _ tts) = parens' unionSym (map prettyAnn tts)
-  prettyAnn (RST.TySet _ NegRep _ [])  = topSym
-  prettyAnn (RST.TySet _ NegRep _ [t]) = prettyAnn t
-  prettyAnn (RST.TySet _ NegRep _ tts) = parens' interSym (map prettyAnn tts)
+  prettyAnn RST.TyTop {}               = topSym
+  prettyAnn RST.TyBot {}               = botSym
+  prettyAnn (RST.TyUnion _ _ ty ty')   = parens' unionSym [prettyAnn ty, prettyAnn ty']
+  prettyAnn (RST.TyInter _ _ ty ty')   = parens' interSym [prettyAnn ty, prettyAnn ty']
   -- Type Variables
   prettyAnn (RST.TyVar _ _ _ tv)       = prettyAnn tv
   -- Recursive types

--- a/src/Translate/Reparse.hs
+++ b/src/Translate/Reparse.hs
@@ -330,18 +330,14 @@ embedType (RST.TyNominal loc _ _ nm args) =
   CST.TyNominal loc (rnTnName nm) (embedVariantTypes args)
 embedType (RST.TySyn loc _ nm _) =
   CST.TyNominal loc (rnTnName nm) []
-embedType (RST.TySet loc PosRep _ []) =
+embedType (RST.TyTop loc _knd) =
   CST.TyTop loc
-embedType (RST.TySet loc PosRep _ [ty1,ty2]) =
-  CST.TyBinOp loc (embedType ty1) UnionOp (embedType ty2)
-embedType (RST.TySet loc PosRep knd (ty1:tys)) =
-  CST.TyBinOp loc (embedType ty1) UnionOp (embedType (RST.TySet loc PosRep knd tys))
-embedType (RST.TySet loc NegRep _ []) =
+embedType (RST.TyBot loc _knd) =
   CST.TyBot loc
-embedType (RST.TySet loc NegRep _ [ty1,ty2]) =
-  CST.TyBinOp loc (embedType ty1) InterOp (embedType ty2)
-embedType (RST.TySet loc NegRep knd (ty1:tys)) =
-  CST.TyBinOp loc (embedType ty1) InterOp (embedType (RST.TySet loc NegRep knd tys))
+embedType (RST.TyUnion loc _knd ty ty') =
+  CST.TyBinOp loc (embedType ty) UnionOp (embedType ty')
+embedType (RST.TyInter loc _knd ty ty') =
+  CST.TyBinOp loc (embedType ty) InterOp (embedType ty')
 embedType (RST.TyRec loc _ tv ty) =
   CST.TyRec loc tv (embedType ty)
 embedType (RST.TyPrim loc _ pt) =

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -155,10 +155,18 @@ subConstraints (SubType annot ty (TySyn _ _ _ ty')) =
 --     ty1 \/ ty2 <: ty3         ~>     ty1 <: ty3   AND  ty2 <: ty3
 --     ty1 <: ty2 /\ ty3         ~>     ty1 <: ty2   AND  ty1 <: ty3
 --
-subConstraints (SubType _ (TySet _ PosRep _ tys) ty) =
-  return [SubType IntersectionUnionSubConstraint ty' ty | ty' <- tys]
-subConstraints (SubType _ ty (TySet _ NegRep _ tys)) =
-  return [SubType IntersectionUnionSubConstraint ty ty' | ty' <- tys]
+subConstraints (SubType _ _ (TyTop _ _)) =
+  pure []
+subConstraints (SubType _ (TyBot _ _) _) =
+  pure []
+subConstraints (SubType _ (TyUnion _ _ ty1 ty2) ty3) =
+  pure [ SubType IntersectionUnionSubConstraint ty1 ty3
+       , SubType IntersectionUnionSubConstraint ty2 ty3
+       ]
+subConstraints (SubType _ ty1 (TyInter _ _ ty2 ty3)) =
+  pure [ SubType IntersectionUnionSubConstraint ty1 ty2
+       , SubType IntersectionUnionSubConstraint ty1 ty3
+       ]
 -- Recursive constraints:
 --
 -- If the left hand side or the right hand side of the constraint is a recursive


### PR DESCRIPTION
Replace TySet by TyUnion, TyInter, TyTop and TyBot in the RST.Types representation.

This makes the code easier to understand, but, more importantly, it is necessary to correctly implement hover-information for union and intersection types that appear in the source code.