### PR TITLE
Add Shifts from "Beyond Polarity" paper

### DIFF
--- a/examples/Shifts.ds
+++ b/examples/Shifts.ds
@@ -1,8 +1,26 @@
 -- The `Shift` connectives mediate between the different evaluation orders.
 -- The specific choice of names for constructors and destructors has been adapted
--- from [1, sec. ]
+-- from [1, p.4]
 --
 -- [1] Paul Downen and Zena Ariola, 
 --     "Beyond Polarity: Towards a Multi-Discipline Intermediate Language with Sharing"
 
 -- Shifts in the style of Levy
+
+data LShiftCBN :  (+a : CBV) -> CBN {
+  Val(a)
+};
+
+codata LShiftCBV : (+a : CBN) -> CBV {
+  Enter(return a)
+};
+
+-- Shifts in the style of Zeilberger
+
+codata ZShiftCBN : (+a : CBV) -> CBN {
+  Eval(return a)
+};
+
+data ZShiftCBV : (+a : CBN) -> CBV {
+  Box(a)
+};


### PR DESCRIPTION
Add the Shifts between CBV and CBN, in the versions of both Levy and Zeilberger.