### PR TITLE
Apply hlint suggestions

### DIFF
--- a/src/Eval/Eval.hs
+++ b/src/Eval/Eval.hs
@@ -23,10 +23,10 @@ evalTermOnce :: Command -> EvalM (Maybe Command)
 evalTermOnce (ExitSuccess _) = return Nothing
 evalTermOnce (ExitFailure _) = return Nothing
 evalTermOnce (Print _ prd cmd) = do
-  liftIO $ ppPrintIO prd 
+  liftIO $ ppPrintIO prd
   return (Just cmd)
 evalTermOnce (Read _ cns) = do
-  tm <- liftIO $ readInt
+  tm <- liftIO readInt
   return (Just (Apply defaultLoc ApplyAnnotOrig (Just (CBox CBV)) tm cns))
 evalTermOnce (Jump _ fv) = do
   cmd <- lookupCommand fv
@@ -100,7 +100,7 @@ evalStepsM cmd = evalSteps' [cmd] cmd
 ---------------------------------------------------------------------------------
 
 eval :: Command -> EvalEnv -> IO (Either Error Command)
-eval cmd env = runEval (evalM cmd) env
+eval cmd = runEval (evalM cmd)
 
 evalSteps :: Command -> EvalEnv -> IO (Either Error [Command])
-evalSteps cmd env = runEval (evalStepsM cmd) env
+evalSteps cmd = runEval (evalStepsM cmd)

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -54,7 +54,7 @@ lookupTerm :: EnvReader a m
            => PrdCnsRep pc -> FreeVarName -> m (TST.Term pc, TypeScheme (PrdCnsToPol pc))
 lookupTerm PrdRep fv = do
   env <- asks fst
-  let err = OtherError Nothing ("Unbound free producer variable " <> ppPrint fv <> " is not contained in environment.\n" <> (ppPrint $ M.keys env))
+  let err = OtherError Nothing ("Unbound free producer variable " <> ppPrint fv <> " is not contained in environment.\n" <> ppPrint (M.keys env))
   let f env = case M.lookup fv (prdEnv env) of
                        Nothing -> Nothing
                        Just (res1,_,res2) -> Just (res1,res2)

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -21,6 +21,7 @@ import Text.Megaparsec
 import Parser.Definition
 import Parser.Lexer
 import Syntax.Common
+import Data.Functor ( ($>) )
 
 ---------------------------------------------------------------------------------
 -- Names
@@ -82,7 +83,7 @@ associativityP = (keywordP KwLeftAssoc >> pure LeftAssoc) <|>
 ---------------------------------------------------------------------------------
 
 evalOrderP :: Parser EvaluationOrder
-evalOrderP = (keywordP KwCBV *> pure CBV) <|> (keywordP KwCBN *> pure CBN)
+evalOrderP = (keywordP KwCBV $> CBV) <|> (keywordP KwCBN $> CBN)
 
 -- | Parses one of the keywords "CBV" or "CBN"
 monoKindP :: Parser MonoKind
@@ -95,19 +96,16 @@ monoKindP = CBox <$> evalOrderP
 ---------------------------------------------------------------------------------
 
 varianceP :: Parser Variance
-varianceP = (symbolP SymPlus *> pure Covariant) <|> (symbolP SymMinus *> pure Contravariant)
+varianceP = (symbolP SymPlus $> Covariant) <|> (symbolP SymMinus $> Contravariant)
 
 polyKindP :: Parser PolyKind
 polyKindP = f <|> g
   where
-    f = do
-      eo <- evalOrderP
-      pure (MkPolyKind [] eo)
+    f = MkPolyKind [] <$> evalOrderP
     g = do
       (kindArgs,_) <- parens (tParamP `sepBy` symbolP SymComma)
       _ <- symbolP SymSimpleRightArrow
-      ret <- evalOrderP
-      pure (MkPolyKind kindArgs ret)
+      MkPolyKind kindArgs <$> evalOrderP
 
 tParamP :: Parser (Variance, TVar, MonoKind)
 tParamP = do

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -68,7 +68,7 @@ commentP = do
   try $ do
     _ <- string "--"
     notFollowedBy (string " |")
-  _ <- (takeWhileP (Just "character") (/= '\n'))
+  _ <- takeWhileP (Just "character") (/= '\n')
   pure ()
 
 -- | Parses a doc comment starting with "-- |" until the end of the line, and does
@@ -123,7 +123,7 @@ floatP = do
 
 lowerCaseId :: Parser (Text, SourcePos)
 lowerCaseId = do
-  (name, pos) <- lexeme $ (T.cons <$> lowerChar <*> (T.pack <$> many alphaNumChar))
+  (name, pos) <- lexeme (T.cons <$> lowerChar <*> (T.pack <$> many alphaNumChar))
   checkReserved name
   pure (name, pos)
 
@@ -197,9 +197,9 @@ data Keyword where
   KwCodata      :: Keyword
   KwSet         :: Keyword
   KwImport      :: Keyword
-  KwPrd         :: Keyword 
-  KwCns         :: Keyword 
-  KwCmd         :: Keyword 
+  KwPrd         :: Keyword
+  KwCns         :: Keyword
+  KwCmd         :: Keyword
   KwReturn      :: Keyword
 
   deriving (Eq, Ord, Enum, Bounded)
@@ -285,10 +285,10 @@ isDeclarationKw KwData        = True
 isDeclarationKw KwCodata      = True
 isDeclarationKw KwSet         = True
 isDeclarationKw KwImport      = True
-isDeclarationKw KwPrd         = False 
-isDeclarationKw KwCns         = False 
-isDeclarationKw KwCmd         = False 
-isDeclarationKw KwReturn      = False 
+isDeclarationKw KwPrd         = False
+isDeclarationKw KwCns         = False
+isDeclarationKw KwCmd         = False
+isDeclarationKw KwReturn      = False
 
 
 -- | All keywords of the language

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -54,7 +54,7 @@ bindingP =  (do _ <- symbolP SymImplicit ;  pos <- getSourcePos; return (CST.FoS
 
 bindingSiteP :: Parser (CST.BindingSite, SourcePos)
 bindingSiteP = do
-  s <- optional $ fst <$> (parens ((fst <$> bindingP) `sepBy` symbolP SymComma))
+  s <- optional $ fst <$> parens ((fst <$> bindingP) `sepBy` symbolP SymComma)
   endPos <- getSourcePos
   return (Data.Maybe.fromMaybe [] s, endPos)
 
@@ -319,17 +319,17 @@ lambdaP = do
   startPos <- getSourcePos
   _ <- symbolP SymBackslash
   bvars <- some $ fst <$> freeVarNameP
-  (do 
+  (do
     _ <- symbolP SymDoubleRightArrow
     (tm, endPos) <- termTopP
-    let t = foldr (\fv t -> CST.Lambda (Loc startPos endPos) fv t) tm bvars
-    return (t,endPos) 
-   ) 
-   <|>   
-   (do 
+    let t = foldr (CST.Lambda (Loc startPos endPos)) tm bvars
+    return (t,endPos)
+   )
+   <|>
+   (do
     _ <- symbolP SymDoubleCoRightArrow
     (tm, endPos) <- termTopP
-    let t = foldr (\fv t -> CST.CoLambda (Loc startPos endPos) fv t) tm bvars
+    let t = foldr (CST.CoLambda (Loc startPos endPos)) tm bvars
     return (t,endPos) )
 
 
@@ -412,13 +412,13 @@ dtorP =  do
   (destructee, endPos) <- termMiddleP
   destructorChain <- destructorChainP
   let (res,_) = foldl (\(tm,sp) (xtor,toss,pos) -> (CST.Dtor (Loc sp pos) xtor tm toss,pos)) (destructee,startPos) destructorChain
-  return $ (res, endPos)
+  return (res, endPos)
 
 termTopP :: Parser (CST.Term, SourcePos)
 termTopP =  do
   startPos <- getSourcePos
   d <- dtorP
-  m <- optional $ applyCmdP
+  m <- optional applyCmdP
   endPos <- getSourcePos
   return $ case m of
     Nothing -> d

--- a/src/Parser/Types.hs
+++ b/src/Parser/Types.hs
@@ -66,13 +66,13 @@ combineXtors = fmap combineXtor
 ---------------------------------------------------------------------------------
 
 nominalTypeArgsP :: SourcePos -> Parser ([Typ], SourcePos)
-nominalTypeArgsP endPos = (parens ((fst <$> typP) `sepBy` symbolP SymComma)) <|> pure ([], endPos)
+nominalTypeArgsP endPos = parens ((fst <$> typP) `sepBy` symbolP SymComma) <|> pure ([], endPos)
 
 -- | Parse a nominal type.
 -- E.g. "Nat", or "List(Nat)"
 nominalTypeP :: Parser (Typ, SourcePos)
 nominalTypeP = do
-  startPos <- getSourcePos 
+  startPos <- getSourcePos
   (name, endPos) <- typeNameP
   (args, endPos') <- nominalTypeArgsP endPos
   pure (TyNominal (Loc startPos endPos') name args, endPos')
@@ -86,7 +86,7 @@ xdataTypeP Data = do
   (xtorSigs, endPos) <- angles (xtorSignatureP `sepBy` symbolP SymComma)
   pure (TyXData (Loc startPos endPos) Data Nothing xtorSigs, endPos)
 xdataTypeP Codata = do
-  startPos <- getSourcePos 
+  startPos <- getSourcePos
   (xtorSigs, endPos) <- braces (xtorSignatureP `sepBy` symbolP SymComma)
   pure (TyXData (Loc startPos endPos) Codata Nothing xtorSigs, endPos)
 
@@ -192,11 +192,11 @@ tyOpChainP = do
           startPos <- getSourcePos
           (op, endPos) <- tyBinOpP
           (typ,pos) <- typAtomP
-          pure (((Loc startPos endPos), op, typ), pos)
+          pure ((Loc startPos endPos, op, typ), pos)
   lst <- some f
   case lst of
     [] -> error "Cannot occur, \"some\" parses non-empty list"
-    (x:xs) -> pure (((fst x) :| (fst <$> xs)), snd (last (x:xs)))
+    (x:xs) -> pure (fst x :| (fst <$> xs), snd (last (x:xs)))
 
 -- | Parse a type
 typP :: Parser (Typ, SourcePos)

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -85,7 +85,7 @@ instance PrettyAnn VariableState where
   prettyAnn VariableState { vst_lowerbounds = lbs , vst_upperbounds = []  } = printLowerBounds lbs
   prettyAnn VariableState { vst_lowerbounds = []  , vst_upperbounds = ubs } = printUpperBounds ubs
   prettyAnn VariableState { vst_lowerbounds = lbs , vst_upperbounds = ubs } =
-    (printLowerBounds lbs) <> line <> (printUpperBounds ubs)
+    printLowerBounds lbs <> line <> printUpperBounds ubs
 
 instance PrettyAnn SolverResult where
   prettyAnn MkSolverResult { tvarSolution } = vsep

--- a/src/Pretty/Errors.hs
+++ b/src/Pretty/Errors.hs
@@ -65,7 +65,7 @@ printLocatedError err@(getLoc -> Just loc) = liftIO $ do
 printLocatedError _ = error "unreachable: Satisfy the pattern match checker :/"
 
 printRegion :: Loc -> IO ()
-printRegion (Loc (SourcePos "<interactive>" _ _) (SourcePos _ _ _)) = return ()
+printRegion (Loc (SourcePos "<interactive>" _ _) SourcePos {}) = return ()
 printRegion (Loc (SourcePos fp line1 _) (SourcePos _ line2 _)) = do
   T.putStrLn ""
   file <- readFile fp

--- a/src/Pretty/Pretty.hs
+++ b/src/Pretty/Pretty.hs
@@ -109,7 +109,7 @@ renderConsole' = \case
   SFail        -> return ()
   SEmpty       -> return ()
   SChar c x    -> do
-    putStr $ c : []
+    putStr [c]
     renderConsole' x
   SText _l t x -> do
     putStr (T.unpack t)

--- a/src/Pretty/TypeAutomata.hs
+++ b/src/Pretty/TypeAutomata.hs
@@ -70,10 +70,10 @@ typeAutParams = defaultParams
     , fillColor $ case nl_pol nl of {Pos -> White; Neg -> Gray}
     , textLabel (pack (ppPrintString (nl :: NodeLabel)))]
   , fmtEdge = \(_,_,elM) -> case elM of
-                              el@(EdgeSymbol _ _ _ _) -> regularEdgeStyle el
+                              el@EdgeSymbol {} -> regularEdgeStyle el
                               (EpsilonEdge _) -> flowEdgeStyle
                               RefineEdge tn -> refEdgeStyle tn
-                              el@(TypeArgEdge _ _ _) -> typeArgEdgeStyle el
+                              el@TypeArgEdge {} -> typeArgEdgeStyle el
   }
   where
     flowEdgeStyle = [arrowTo dotArrow, Style [SItem Dashed []]]

--- a/src/Pretty/Types.hs
+++ b/src/Pretty/Types.hs
@@ -92,7 +92,7 @@ instance PrettyAnn CST.XtorSig where
 
 instance PrettyAnn (RST.Typ pol) where
   prettyAnn typ = prettyAnn (embedType typ)
-  
+
 instance PrettyAnn CST.Typ where
   -- Top and Bottom lattice types
   prettyAnn CST.TyTop {} = topSym
@@ -136,9 +136,9 @@ instance PrettyAnn (RST.TypeScheme pol) where
   prettyAnn tys = prettyAnn (embedTypeScheme tys)
 
 instance PrettyAnn CST.TypeScheme where
-  prettyAnn (CST.TypeScheme { ts_vars = [], ts_monotype }) =
+  prettyAnn CST.TypeScheme { ts_vars = [], ts_monotype } =
     prettyAnn ts_monotype
-  prettyAnn (CST.TypeScheme { ts_vars, ts_monotype }) =
+  prettyAnn CST.TypeScheme { ts_vars, ts_monotype } =
     forallSym <+>
     sep (prettyAnn <$> ts_vars ) <>
     "." <+>

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -246,4 +246,4 @@ resolveDecl CST.ParseErrorDecl =
   throwError (OtherError Nothing "Unreachable: ParseErrorDecl cannot be parsed")
 
 resolveProgram :: CST.Program -> ResolverM RST.Program
-resolveProgram = sequence . fmap resolveDecl
+resolveProgram = mapM resolveDecl

--- a/src/Resolution/SymbolTable.hs
+++ b/src/Resolution/SymbolTable.hs
@@ -118,11 +118,11 @@ createSymbolTable mn prog = createSymbolTableAcc prog emptySymbolTable
       createSymbolTableAcc xs acc'
 
 createSymbolTable' :: MonadError Error m
-                   => ModuleName 
-                   -> Declaration 
-                   -> SymbolTable 
+                   => ModuleName
+                   -> Declaration
+                   -> SymbolTable
                    -> m SymbolTable
-createSymbolTable' _ (XtorDecl (MkStructuralXtorDeclaration {strxtordecl_loc, strxtordecl_xdata, strxtordecl_name, strxtordecl_arity })) st = do
+createSymbolTable' _ (XtorDecl MkStructuralXtorDeclaration {strxtordecl_loc, strxtordecl_xdata, strxtordecl_name, strxtordecl_arity }) st = do
   -- Check whether the xtor name is already declared in this module
   checkFreshXtorName strxtordecl_loc strxtordecl_name st
   let xtorResolve = XtorNameResult strxtordecl_xdata Structural (fst <$> strxtordecl_arity)
@@ -149,9 +149,9 @@ createSymbolTable' _ (TyOpDecl MkTyOpDeclaration { tyopdecl_sym, tyopdecl_prec, 
                       , assoc = tyopdecl_assoc
                       , desugar = NominalDesugaring tyopdecl_res
                       }
-    pure $ st { tyOps = tyOp : (tyOps st) }
-createSymbolTable' _ (ImportDecl (MkImportDeclaration { imprtdecl_loc, imprtdecl_module })) st =
-  pure $ st { imports = (imprtdecl_module,imprtdecl_loc):(imports st) }
+    pure $ st { tyOps = tyOp : tyOps st }
+createSymbolTable' _ (ImportDecl MkImportDeclaration { imprtdecl_loc, imprtdecl_module }) st =
+  pure $ st { imports = (imprtdecl_module,imprtdecl_loc):imports st }
 createSymbolTable' mn (TySynDecl MkTySynDeclaration { tysyndecl_loc, tysyndecl_doc, tysyndecl_name, tysyndecl_res }) st = do
   -- Check whether the TypeName is already declared in this module
   checkFreshTypeName tysyndecl_loc tysyndecl_name st

--- a/src/Resolution/Terms.hs
+++ b/src/Resolution/Terms.hs
@@ -61,7 +61,7 @@ analyzePattern dc (CST.XtorPat loc xt args) = do
     0 -> pure $ ExplicitPattern loc xt $ zip arity (CST.fromFVOrStar <$> args)
     1 -> do
       let zipped :: [(PrdCns, CST.FVOrStar)] = zip arity args
-      let (args1,((pc,_):args2)) = break (\(_,x) -> CST.isStar x) zipped
+      let (args1,(pc,_):args2) = break (\(_,x) -> CST.isStar x) zipped
       case pc of
         Cns -> pure $ ImplicitPrdPattern loc xt (second CST.fromFVOrStar <$> args1, PrdRep, second CST.fromFVOrStar <$> args2)
         Prd -> pure $ ImplicitCnsPattern loc xt (second CST.fromFVOrStar <$> args1, CnsRep, second CST.fromFVOrStar <$> args2)
@@ -119,7 +119,7 @@ analyzeCase :: DataCodata
             -- ^ Whether a constructor (Data) or destructor (Codata) is expected in this case
             -> CST.TermCase
             -> ResolverM SomeIntermediateCase
-analyzeCase dc (CST.MkTermCase { tmcase_loc, tmcase_pat, tmcase_term }) = do
+analyzeCase dc CST.MkTermCase { tmcase_loc, tmcase_pat, tmcase_term } = do
   analyzedPattern <- analyzePattern dc tmcase_pat
   case analyzedPattern of
     ExplicitPattern _ xt pat -> pure $ ExplicitCase $ MkIntermediateCase
@@ -281,7 +281,7 @@ resolveCommand (CST.CoLambda loc _ _) =
 
 casesToNS :: [CST.TermCase] -> ResolverM NominalStructural
 casesToNS [] = pure Structural
-casesToNS ((CST.MkTermCase { tmcase_loc, tmcase_pat = CST.XtorPat _ tmcase_name _ }):_) = do
+casesToNS (CST.MkTermCase { tmcase_loc, tmcase_pat = CST.XtorPat _ tmcase_name _ }:_) = do
   (_, XtorNameResult _ ns _) <- lookupXtor tmcase_loc tmcase_name
   pure ns
 
@@ -325,13 +325,13 @@ analyzeSubstitution loc xtor arity subst = do
   when (length arity /= length subst) $
     throwError $ LowerError (Just loc) $ XtorArityMismatch xtor (length arity) (length subst)
   -- Dispatch on the number of stars in the substitution
-  case (length (filter isStarT subst)) of
+  case length (filter isStarT subst) of
     0 -> pure $ ExplicitSubst (zip arity (toTm <$> subst))
     1 -> do
       let zipped :: [(PrdCns, CST.TermOrStar)] = zip arity subst
       case span (not . isStarT . snd) zipped of
         (subst1,(pc,_):subst2) -> pure $ ImplicitSubst (second toTm <$> subst1) pc (second toTm <$> subst2)
-        _ -> throwError $ OtherError (Just loc) ("Compiler bug in analyzeSubstitution")
+        _ -> throwError $ OtherError (Just loc) "Compiler bug in analyzeSubstitution"
     n -> throwError $ OtherError (Just loc) ("At most one star expected. Got " <> T.pack (show n) <> " stars.")
 
 resolvePrdCnsTerm :: PrdCns -> CST.Term -> ResolverM RST.PrdCnsTerm
@@ -396,14 +396,14 @@ resolveTerm rep (CST.Semi loc xtor subst tm) = do
         PrdRep ->
           throwError (OtherError (Just loc) "Tried to resolve Semi to a producer, but implicit argument stands for a producer")
         CnsRep -> do
-          subst1' <- forM subst1 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
-          subst2' <- forM subst2 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
+          subst1' <- forM subst1 $ uncurry resolvePrdCnsTerm
+          subst2' <- forM subst2 $ uncurry resolvePrdCnsTerm
           pure $ RST.Semi loc CnsRep ns xtor (subst1', CnsRep, subst2') tm'
     ImplicitSubst subst1 Cns subst2 -> do
       case rep of
         PrdRep -> do
-          subst1' <- forM subst1 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
-          subst2' <- forM subst2 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
+          subst1' <- forM subst1 $ uncurry resolvePrdCnsTerm
+          subst2' <- forM subst2 $ uncurry resolvePrdCnsTerm
           pure $ RST.Semi loc PrdRep ns xtor (subst1', PrdRep, subst2') tm'
         CnsRep ->
           throwError (OtherError (Just loc) "Tried to resolve Semi to a producer, but implicit argument stands for a producer")
@@ -421,13 +421,13 @@ resolveTerm rep (CST.Dtor loc xtor tm subst) = do
         PrdRep -> do
           throwError (OtherError (Just loc) "Tried to resolve Dtor to a producer, but implicit argument stands for a producer")
         CnsRep -> do
-          subst1' <- forM subst1 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
-          subst2' <- forM subst2 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
+          subst1' <- forM subst1 $ uncurry resolvePrdCnsTerm
+          subst2' <- forM subst2 $ uncurry resolvePrdCnsTerm
           pure $ RST.Dtor loc CnsRep ns xtor tm' (subst1', CnsRep, subst2')
     ImplicitSubst subst1 Cns subst2 -> do
       case rep of
         PrdRep -> do
-          subst1' <- forM subst1 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
+          subst1' <- forM subst1 $ uncurry resolvePrdCnsTerm
           subst2' <- forM subst2 $ \(pc,tm) -> resolvePrdCnsTerm pc tm
           pure $ RST.Dtor loc PrdRep ns xtor tm' (subst1', PrdRep, subst2')
         CnsRep -> do
@@ -521,14 +521,14 @@ resolveTerm CnsRep (CST.NatLit loc _ns _i) =
 -- Function specific syntax sugar
 ---------------------------------------------------------------------------------
 resolveTerm PrdRep (CST.Lambda loc fv tm) =
-  do 
-    tm' <- resolveTerm PrdRep tm 
-    let tm'' = RST.termClosing [(Prd,fv)] tm'  
+  do
+    tm' <- resolveTerm PrdRep tm
+    let tm'' = RST.termClosing [(Prd,fv)] tm'
     return $ RST.Lambda loc PrdRep fv tm''
 resolveTerm CnsRep (CST.CoLambda loc fv tm) =
-  do 
-    tm' <- resolveTerm CnsRep tm 
-    let tm'' = RST.termClosing [(Cns,fv)] tm'  
+  do
+    tm' <- resolveTerm CnsRep tm
+    let tm'' = RST.termClosing [(Cns,fv)] tm'
     return $ RST.Lambda loc CnsRep fv tm''
 resolveTerm rep (CST.FunApp loc fun arg) =
   resolveApp rep loc fun arg

--- a/src/Sugar/Desugar.hs
+++ b/src/Sugar/Desugar.hs
@@ -71,13 +71,13 @@ desugarCmdCase :: RST.CmdCase -> Core.CmdCase
 desugarCmdCase (RST.MkCmdCase loc pat cmd) =
   Core.MkCmdCase loc (desugarPat pat) (desugarCmd cmd)
 
-desugarTermCaseI :: RST.TermCaseI pc -> Core.TermCaseI pc 
+desugarTermCaseI :: RST.TermCaseI pc -> Core.TermCaseI pc
 desugarTermCaseI (RST.MkTermCaseI loc pti t) = Core.MkTermCaseI loc (desugarPatI pti) (desugarTerm t)
 
-desugarPatI :: RST.PatternI -> Core.PatternI 
+desugarPatI :: RST.PatternI -> Core.PatternI
 desugarPatI (RST.XtorPatI loc xt args) = Core.XtorPatI loc xt args
 
-desugarTermCase :: RST.TermCase pc -> Core.TermCase pc 
+desugarTermCase :: RST.TermCase pc -> Core.TermCase pc
 desugarTermCase (RST.MkTermCase loc pat t) = Core.MkTermCase loc (desugarPat pat) (desugarTerm t)
 
 desugarCmd :: RST.Command -> Core.Command
@@ -101,12 +101,12 @@ desugarCmd (RST.PrimOp loc pt op subst) =
 ---------------------------------------------------------------------------------
 
 desugarCmd (RST.CaseOfCmd loc ns t cases) =
-  Core.CaseOfCmd loc ns (desugarTerm t) (desugarCmdCase <$> cases) 
+  Core.CaseOfCmd loc ns (desugarTerm t) (desugarCmdCase <$> cases)
 desugarCmd (RST.CocaseOfCmd loc ns t cases) =
-  Core.CocaseOfCmd loc ns (desugarTerm t) (desugarCmdCase <$> cases) 
-desugarCmd (RST.CaseOfI loc rep ns t cases) = 
+  Core.CocaseOfCmd loc ns (desugarTerm t) (desugarCmdCase <$> cases)
+desugarCmd (RST.CaseOfI loc rep ns t cases) =
   Core.CaseOfI loc rep ns (desugarTerm t) (desugarTermCaseI  <$> cases )
-desugarCmd (RST.CocaseOfI loc rep ns t cases) = 
+desugarCmd (RST.CocaseOfI loc rep ns t cases) =
   Core.CocaseOfI loc rep ns (desugarTerm t) (desugarTermCaseI  <$> cases )
 
 ---------------------------------------------------------------------------------
@@ -147,7 +147,7 @@ desugarDecl (RST.SetDecl decl) =
   Core.SetDecl decl
 desugarDecl (RST.TyOpDecl decl) =
   Core.TyOpDecl decl
-desugarDecl (RST.TySynDecl decl) = 
+desugarDecl (RST.TySynDecl decl) =
   Core.TySynDecl decl
 
 desugarProgram :: RST.Program -> Core.Program
@@ -158,7 +158,7 @@ desugarEnvironment :: Map ModuleName Environment -> EvalEnv
 desugarEnvironment map = fold $ desugarEnvironment' <$> M.elems map
 
 desugarEnvironment' :: Environment -> EvalEnv
-desugarEnvironment' (MkEnvironment { prdEnv, cnsEnv, cmdEnv }) = (prd,cns,cmd)
+desugarEnvironment' MkEnvironment { prdEnv, cnsEnv, cmdEnv } = (prd,cns,cmd)
   where
     prd = (\(tm,_,_) -> tm) <$> prdEnv
     cns = (\(tm,_,_) -> tm) <$> cnsEnv

--- a/src/Syntax/Common/Names.hs
+++ b/src/Syntax/Common/Names.hs
@@ -56,7 +56,7 @@ data Associativity where
   RightAssoc :: Associativity
   deriving (Eq, Show, Ord)
 
-data Precedence = MkPrecedence Int
+newtype Precedence = MkPrecedence Int
   deriving (Eq, Show, Ord)
 
 ---------------------------------------------------------------------------------

--- a/src/Syntax/Common/TypesPol.hs
+++ b/src/Syntax/Common/TypesPol.hs
@@ -175,7 +175,7 @@ instance FreeTVars (LinearContext pol) where
   freeTVars ctxt = S.unions (freeTVars <$> ctxt)
 
 instance FreeTVars (XtorSig pol) where
-  freeTVars (MkXtorSig { sig_args }) = freeTVars sig_args
+  freeTVars MkXtorSig { sig_args } = freeTVars sig_args
 
 -- | Generalize over all free type variables of a type.
 generalize :: Typ pol -> TypeScheme pol
@@ -185,7 +185,7 @@ generalize ty = TypeScheme defaultLoc (S.toList (freeTVars ty)) ty
 -- Bisubstitution and Zonking
 ------------------------------------------------------------------------------
 
-data Bisubstitution = MkBisubstitution { uvarSubst :: Map TVar (Typ Pos, Typ Neg) }
+newtype Bisubstitution = MkBisubstitution { uvarSubst :: Map TVar (Typ Pos, Typ Neg) }
 
 -- | Class of types for which a Bisubstitution can be applied.
 class Zonk (a :: Type) where

--- a/src/Syntax/TST/Terms.hs
+++ b/src/Syntax/TST/Terms.hs
@@ -191,7 +191,7 @@ termOpeningRec k subst bv@(BoundVar _ pcrep _ (i,j)) | i == k    = case (pcrep, 
                                                                       (CnsRep, CnsTerm tm) -> tm
                                                                       _                    -> error "termOpeningRec BOOM"
                                                    | otherwise = bv
-termOpeningRec _ _ fv@(FreeVar _ _ _ _)       = fv
+termOpeningRec _ _ fv@FreeVar {} = fv
 termOpeningRec k args (Xtor loc annot rep ty ns xt subst) =
   Xtor loc annot rep ty ns xt (pctermOpeningRec k args <$> subst)
 termOpeningRec k args (XCase loc annot rep ty ns cases) =
@@ -231,7 +231,7 @@ pctermClosingRec k vars (CnsTerm tm) = CnsTerm $ termClosingRec k vars tm
 
 termClosingRec :: Int -> [(PrdCns, FreeVarName)] -> Term pc -> Term pc
 -- Core constructs
-termClosingRec _ _ bv@(BoundVar _ _ _ _) = bv
+termClosingRec _ _ bv@BoundVar {} = bv
 termClosingRec k vars (FreeVar loc PrdRep ty v) | isJust ((Prd,v) `elemIndex` vars) = BoundVar loc PrdRep ty (k, fromJust ((Prd,v) `elemIndex` vars))
                                                    | otherwise = FreeVar loc PrdRep ty v
 termClosingRec k vars (FreeVar loc CnsRep ty v) | isJust ((Cns,v) `elemIndex` vars) = BoundVar loc CnsRep ty (k, fromJust ((Cns,v) `elemIndex` vars))
@@ -379,5 +379,5 @@ shiftCmdRec dir n (PrimOp ext pt op subst) =
 
 -- | Shift all unbound BoundVars up by one.
 shiftCmd :: ShiftDirection -> Command -> Command
-shiftCmd dir cmd = shiftCmdRec dir 0 cmd
+shiftCmd dir = shiftCmdRec dir 0
 

--- a/src/Translate/Reparse.hs
+++ b/src/Translate/Reparse.hs
@@ -106,11 +106,11 @@ openTermComplete (RST.CaseI loc rep ns cases) =
 openTermComplete (RST.CocaseI loc rep ns cocases) =
   RST.CocaseI loc rep ns (openTermCaseI <$> cocases)
 openTermComplete (RST.Lambda loc pc fv tm) =
-  let 
-    tm' = openTermComplete tm 
-    tm'' = case pc of PrdRep -> RST.termOpening [(RST.PrdTerm (RST.FreeVar defaultLoc PrdRep fv))] tm'  
-                      CnsRep -> RST.termOpening [(RST.CnsTerm (RST.FreeVar defaultLoc CnsRep fv))] tm' 
-                        
+  let
+    tm' = openTermComplete tm
+    tm'' = case pc of PrdRep -> RST.termOpening [RST.PrdTerm (RST.FreeVar defaultLoc PrdRep fv)] tm'
+                      CnsRep -> RST.termOpening [RST.CnsTerm (RST.FreeVar defaultLoc CnsRep fv)] tm'
+
   in
   RST.Lambda loc pc fv tm''
 -- Primitive constructs
@@ -211,9 +211,9 @@ createNamesTerm (RST.CaseI loc rep ns cases) = do
 createNamesTerm (RST.CocaseI loc rep ns cases) = do
   cases' <- sequence (createNamesTermCaseI <$> cases)
   pure $ RST.CocaseI loc rep ns cases'
-createNamesTerm (RST.Lambda loc rep fvs tm) = do 
-  tm' <- createNamesTerm tm 
-  pure $ RST.Lambda loc rep fvs tm'   
+createNamesTerm (RST.Lambda loc rep fvs tm) = do
+  tm' <- createNamesTerm tm
+  pure $ RST.Lambda loc rep fvs tm'
 -- Primitive constructs
 createNamesTerm (RST.PrimLitI64 loc i) =
   pure (RST.PrimLitI64 loc i)
@@ -260,7 +260,7 @@ createNamesCommand (RST.CocaseOfI loc rep ns tm cases) = do
 
 createNamesPat :: RST.Pattern -> CreateNameM RST.Pattern
 createNamesPat (RST.XtorPat loc xt args) = do
-  args' <- sequence $ (\(pc,_) -> (fresh pc >>= \v -> return (pc,v))) <$> args
+  args' <- sequence $ (\(pc,_) -> fresh pc >>= \v -> return (pc,v)) <$> args
   pure $ RST.XtorPat loc xt args'
 
 createNamesPatI :: RST.PatternI -> CreateNameM RST.PatternI
@@ -308,7 +308,7 @@ embedTerm RST.BoundVar{} =
 embedTerm (RST.FreeVar loc _ fv) =
   CST.Var loc fv
 embedTerm (RST.Xtor loc _ _ xt subst) =
-  CST.Xtor loc xt (CST.ToSTerm <$> (embedSubst subst))
+  CST.Xtor loc xt (CST.ToSTerm <$> embedSubst subst)
 embedTerm (RST.XCase loc PrdRep _ cases) =
   CST.Cocase loc (embedCmdCase <$> cases)
 embedTerm (RST.XCase loc CnsRep _ cases) =
@@ -317,13 +317,13 @@ embedTerm (RST.MuAbs loc _ fv cmd) =
   CST.MuAbs loc (fromJust fv) (embedCommand cmd)
 -- Syntactic sugar
 embedTerm (RST.Semi loc _ _ (MkXtorName "CoAp")  ([RST.CnsTerm t],CnsRep,[]) tm) =
-  CST.FunApp loc (embedTerm tm) (embedTerm t) 
+  CST.FunApp loc (embedTerm tm) (embedTerm t)
 embedTerm (RST.Semi _loc _ _ (MkXtorName "CoAp")  other _tm) =
   error $ "embedTerm: " ++ show  other
 embedTerm (RST.Semi loc _ _ xt substi tm) =
   CST.Semi loc xt (embedSubstI substi) (embedTerm tm)
 embedTerm (RST.Dtor loc _ _ (MkXtorName "Ap") tm ([RST.PrdTerm t],PrdRep,[])) =
-  CST.FunApp loc (embedTerm tm) (embedTerm t) 
+  CST.FunApp loc (embedTerm tm) (embedTerm t)
 embedTerm (RST.Dtor loc _ _ xt tm substi) =
   CST.Dtor loc xt (embedTerm tm) (embedSubstI substi)
 embedTerm (RST.CaseOf loc _ _ tm cases) =
@@ -334,9 +334,9 @@ embedTerm (RST.CaseI loc _ _ cases) =
   CST.Case loc (embedTermCaseI <$> cases)
 embedTerm (RST.CocaseI loc _ _ cases) =
   CST.Cocase loc (embedTermCaseI <$> cases)
-embedTerm (RST.Lambda loc PrdRep fvs tm) = 
+embedTerm (RST.Lambda loc PrdRep fvs tm) =
   CST.Lambda loc fvs (embedTerm tm)
-embedTerm (RST.Lambda loc CnsRep fvs tm) = 
+embedTerm (RST.Lambda loc CnsRep fvs tm) =
   CST.CoLambda loc fvs (embedTerm tm)
 embedTerm (RST.PrimLitI64 loc i) =
   CST.PrimLitI64 loc i
@@ -370,7 +370,7 @@ embedCommand (RST.ExitFailure loc) =
   CST.PrimCmdTerm $ CST.ExitFailure loc
 embedCommand (RST.PrimOp loc ty op subst) =
   CST.PrimCmdTerm $ CST.PrimOp loc ty op (embedSubst subst)
-embedCommand (RST.CaseOfCmd loc _ns tm cases) = 
+embedCommand (RST.CaseOfCmd loc _ns tm cases) =
   CST.CaseOf loc (embedTerm tm) (embedCmdCase <$> cases)
 embedCommand (RST.CocaseOfCmd loc _ns tm cases) =
   CST.CocaseOf loc (embedTerm tm) (embedCmdCase <$> cases)
@@ -565,7 +565,7 @@ reparseTyOpDecl RST.MkTyOpDeclaration { tyopdecl_loc, tyopdecl_doc, tyopdecl_sym
                         }
 
 reparseDecl :: RST.Declaration -> CST.Declaration
-reparseDecl (RST.PrdCnsDecl _ decl) = 
+reparseDecl (RST.PrdCnsDecl _ decl) =
   CST.PrdCnsDecl (reparsePrdCnsDeclaration decl)
 reparseDecl (RST.CmdDecl decl) =
   CST.CmdDecl (reparseCommandDeclaration decl)

--- a/src/TypeAutomata/FromAutomaton.hs
+++ b/src/TypeAutomata/FromAutomaton.hs
@@ -72,7 +72,7 @@ checkCache i = do
 nodeToTVars :: PolarityRep pol -> Node -> AutToTypeM [Typ pol]
 nodeToTVars rep i = do
   tvMap <- asks tvMap
-  return (TyVar defaultLoc rep Nothing <$> (S.toList $ fromJust $ M.lookup i tvMap))
+  return (TyVar defaultLoc rep Nothing <$> S.toList (fromJust $ M.lookup i tvMap))
 
 nodeToOuts :: Node -> AutToTypeM [(EdgeLabelNormal, Node)]
 nodeToOuts i = do

--- a/src/TypeAutomata/RemoveEpsilon.hs
+++ b/src/TypeAutomata/RemoveEpsilon.hs
@@ -1,6 +1,7 @@
 module TypeAutomata.RemoveEpsilon ( removeEpsilonEdges ) where
 
 import Data.Graph.Inductive.Graph
+import Data.Bifunctor ( Bifunctor(first) )
 
 import TypeAutomata.Definition
 
@@ -49,17 +50,17 @@ removeEpsilonEdgesFromNode n (gr,starts) = (newGraph, newStarts)
                 else starts
 
 fromEpsGr :: TypeGrEps -> TypeGr
-fromEpsGr gr = gmap mapfun gr
+fromEpsGr = gmap mapfun
   where
     foo :: Adj EdgeLabelEpsilon -> Adj EdgeLabelNormal
-    foo = fmap (\(el, node) -> (unsafeEmbedEdgeLabel el, node))
+    foo = fmap (first unsafeEmbedEdgeLabel)
     mapfun :: Context NodeLabel EdgeLabelEpsilon -> Context NodeLabel EdgeLabelNormal
     mapfun (ins,i,nl,outs) = (foo ins, i, nl, foo outs)
 
 removeEpsilonEdges :: TypeAutEps pol -> TypeAut pol
 removeEpsilonEdges TypeAut { ta_pol, ta_starts, ta_core = TypeAutCore { ta_flowEdges, ta_gr } } =
   let
-    (gr', starts') = foldr (.) id (map removeEpsilonEdgesFromNode (nodes ta_gr)) (ta_gr, ta_starts)
+    (gr', starts') = foldr ((.) . removeEpsilonEdgesFromNode) id (nodes ta_gr) (ta_gr, ta_starts)
   in
    TypeAut { ta_pol = ta_pol
            , ta_starts = starts'

--- a/src/TypeAutomata/Subsume.hs
+++ b/src/TypeAutomata/Subsume.hs
@@ -30,7 +30,7 @@ shiftGraph shift = mapTypeAut (+shift)
 
 -- Constructs the union of two TypeAuts, assumes that the node ranges don't overlap.
 unsafeUnion :: TypeAutDet pol -> TypeAutDet pol -> TypeAut pol
-unsafeUnion (TypeAut polrep (Identity starts1) (TypeAutCore gr1 flowEdges1)) 
+unsafeUnion (TypeAut polrep (Identity starts1) (TypeAutCore gr1 flowEdges1))
             (TypeAut _      (Identity starts2) (TypeAutCore gr2 flowEdges2)) =
   TypeAut { ta_pol = polrep
           , ta_starts = [starts1, starts2]
@@ -56,7 +56,7 @@ isSubtype aut1 aut2 = case (startPolarity aut1, startPolarity aut2) of
     fun = minimize . removeAdmissableFlowEdges . determinize
 
 typeAutEqual :: TypeAutDet pol -> TypeAutDet pol -> Bool
-typeAutEqual (TypeAut _ (Identity start1) (TypeAutCore gr1 flowEdges1)) 
+typeAutEqual (TypeAut _ (Identity start1) (TypeAutCore gr1 flowEdges1))
              (TypeAut _ (Identity start2) (TypeAutCore gr2 flowEdges2))
   = case runStateT (typeAutEqualM (gr1, start1) (gr2, start2)) M.empty of
       Nothing -> False
@@ -82,8 +82,8 @@ typeAutEqualM (gr1, n) (gr2, m) = do
 
 subsume :: PolarityRep pol -> TypeScheme pol -> TypeScheme pol -> Either Error Bool
 subsume polrep ty1 ty2 = do
-  aut1 <- (minimize . removeAdmissableFlowEdges . determinize . removeEpsilonEdges) <$> typeToAut ty1
-  aut2 <- (minimize . removeAdmissableFlowEdges . determinize . removeEpsilonEdges) <$> typeToAut ty2
+  aut1 <- minimize . removeAdmissableFlowEdges . determinize . removeEpsilonEdges <$> typeToAut ty1
+  aut2 <- minimize . removeAdmissableFlowEdges . determinize . removeEpsilonEdges <$> typeToAut ty2
   case polrep of
     PosRep -> pure (isSubtype aut1 aut2)
     NegRep -> pure (isSubtype aut2 aut1)

--- a/src/TypeInference/Coalescing.hs
+++ b/src/TypeInference/Coalescing.hs
@@ -2,6 +2,7 @@ module TypeInference.Coalescing ( coalesce ) where
 
 import Control.Monad.State
 import Control.Monad.Reader
+import Data.Bifunctor ( Bifunctor(second) )
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Set (Set)
@@ -49,12 +50,12 @@ getRecVar ptv = do
     case M.lookup ptv mp of
       Nothing -> do
           recVar <- freshRecVar
-          modify (\(i,m) -> (i,M.insert ptv recVar m))
+          modify (second (M.insert ptv recVar))
           return recVar
       Just tv -> return tv
 
 coalesce :: SolverResult -> Bisubstitution
-coalesce result@(MkSolverResult { tvarSolution }) = MkBisubstitution (M.fromList xs)
+coalesce result@MkSolverResult { tvarSolution } = MkBisubstitution (M.fromList xs)
     where
         res = M.keys tvarSolution
         f tvar = (tvar, ( runCoalesceM result $ coalesceType $ TyVar defaultLoc PosRep Nothing tvar
@@ -113,16 +114,16 @@ coalesceType (TyInter loc knd ty1 ty2) = do
     ty2' <- coalesceType ty2
     pure (TyInter loc knd ty1' ty2')
 coalesceType (TyRec loc PosRep tv ty) = do
-    modify (\(i,m) -> (i, M.insert (tv, Pos) tv m))
-    let f = (\(x,s) -> (x, S.insert (tv,Pos) s))
+    modify (second (M.insert (tv, Pos) tv))
+    let f = second (S.insert (tv, Pos))
     ty' <- local f $ coalesceType ty
     return $ TyRec loc PosRep tv ty'
 coalesceType (TyRec loc NegRep tv ty) = do
-    modify (\(i,m) -> (i, M.insert (tv, Neg) tv m))
-    let f = (\(x,s) -> (x, S.insert (tv,Neg) s))
+    modify (second (M.insert (tv, Neg) tv))
+    let f = second (S.insert (tv, Neg))
     ty' <- local f $ coalesceType ty
     return $ TyRec loc NegRep tv ty'
-coalesceType t@(TyPrim _ _ _) = return t
+coalesceType t@TyPrim {} = return t
 coalesceType (TyFlipPol _ _) = error "Tried to coalesce TyFlipPol"
 
 

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -63,8 +63,8 @@ data VariableState = VariableState
   }
 
 emptyVarState :: MonoKind -> VariableState
-emptyVarState kind = VariableState [] [] kind
+emptyVarState = VariableState [] []
 
-data SolverResult = MkSolverResult
+newtype SolverResult = MkSolverResult
   { tvarSolution :: Map TVar VariableState
     }

--- a/src/TypeInference/GenerateConstraints/Definition.hs
+++ b/src/TypeInference/GenerateConstraints/Definition.hs
@@ -74,7 +74,7 @@ initialState = GenerateState { varCount = 0, constraintSet = initialConstraintSe
 -- The context contains monotypes, whereas the environment contains type schemes.
 ---------------------------------------------------------------------------------------------
 
-data GenerateReader = GenerateReader { context :: [LinearContext Pos]
+newtype GenerateReader = GenerateReader { context :: [LinearContext Pos]
                                      }
 
 initialReader :: Map ModuleName Environment -> (Map ModuleName Environment, GenerateReader)
@@ -149,8 +149,7 @@ freshTVarsForTypeParams rep dd = do
 ---------------------------------------------------------------------------------------------
 
 withContext :: LinearContext 'Pos -> GenM a -> GenM a
-withContext ctx m =
-  local (\(env,gr@GenerateReader{..}) -> (env, gr { context = ctx:context })) m
+withContext ctx = local (\(env,gr@GenerateReader{..}) -> (env, gr { context = ctx:context }))
 
 ---------------------------------------------------------------------------------------------
 -- Looking up types in the context and environment
@@ -162,7 +161,7 @@ lookupContext rep (i,j) = do
   ctx <- asks (context . snd)
   case indexMaybe ctx i of
     Nothing -> throwGenError ["Bound Variable out of bounds: ", "PrdCns: " <> T.pack (show rep),  "Index: " <> T.pack (show (i,j))]
-    Just (lctxt) -> case indexMaybe lctxt j of
+    Just lctxt -> case indexMaybe lctxt j of
       Nothing -> throwGenError ["Bound Variable out of bounds: ", "PrdCns: " <> T.pack (show rep),  "Index: " <> T.pack (show (i,j))]
       Just ty -> case (rep, ty) of
         (PrdRep, PrdCnsType PrdRep ty) -> return ty

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -153,7 +153,7 @@ genConstraintsTerm (Core.XCase _ _ _ Nominal []) =
   throwGenError ["Unreachable: A nominal match needs to have at least one case."]
 genConstraintsTerm (Core.XCase loc annot rep Nominal cases@(pmcase:_)) = do
   -- We lookup the data declaration based on the first pattern match case.
-  decl <- lookupDataDecl (case (Core.cmdcase_pat pmcase) of (Core.XtorPat _ xt _) -> xt)
+  decl <- lookupDataDecl (case Core.cmdcase_pat pmcase of (Core.XtorPat _ xt _) -> xt)
   -- We check that all cases in the pattern match belong to the type declaration.
   checkCorrectness ((\cs -> case Core.cmdcase_pat cs of Core.XtorPat _ xt _ -> xt) <$> cases) decl
   -- We check that all xtors in the type declaration are matched against.
@@ -184,7 +184,7 @@ genConstraintsTerm (Core.XCase _ _ _ Refinement []) =
   throwGenError ["Unreachable: A refinement match needs to have at least one case."]
 genConstraintsTerm (Core.XCase loc annot rep Refinement cases@(pmcase:_)) = do
   -- We lookup the data declaration based on the first pattern match case.
-  decl <- lookupDataDecl (case (Core.cmdcase_pat pmcase) of (Core.XtorPat _ xt _) -> xt)
+  decl <- lookupDataDecl (case Core.cmdcase_pat pmcase of (Core.XtorPat _ xt _) -> xt)
   -- We check that all cases in the pattern match belong to the type declaration.
   checkCorrectness ((\cs -> case Core.cmdcase_pat cs of Core.XtorPat _ xt _ -> xt) <$> cases) decl
   inferredCases <- forM cases (\Core.MkCmdCase {cmdcase_loc, cmdcase_pat = Core.XtorPat loc xt args , cmdcase_cmd} -> do

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -45,13 +45,13 @@ runSolverM m env initSt = runExcept (runStateT (runReaderT m (env,())) initSt)
 ------------------------------------------------------------------------------
 
 addToCache :: Constraint ConstraintInfo -> SolverM ()
-addToCache cs = modifyCache (S.insert (const () <$> cs)) -- We delete the annotation when inserting into cache
+addToCache cs = modifyCache (S.insert (() <$ cs)) -- We delete the annotation when inserting into cache
   where
     modifyCache :: (Set (Constraint ()) -> Set (Constraint ())) -> SolverM ()
     modifyCache f = modify (\(SolverState gr cache) -> SolverState gr (f cache))
 
 inCache :: Constraint ConstraintInfo -> SolverM Bool
-inCache cs = gets sst_cache >>= \cache -> pure ((const () <$> cs) `elem` cache)
+inCache cs = gets sst_cache >>= \cache -> pure ((() <$ cs) `elem` cache)
 
 modifyBounds :: (VariableState -> VariableState) -> TVar -> SolverM ()
 modifyBounds f uv = modify (\(SolverState varMap cache) -> SolverState (M.adjust f uv varMap) cache)
@@ -302,13 +302,13 @@ subConstraints (SubType _ t1@TyNominal{} t2@TyCodata{}) =
 -- dealt with in the function `solve`. Calling the function `subConstraints` with an
 -- atomic constraint is an implementation bug.
 --
-subConstraints (SubType _ ty1@(TyVar _ _ _ _ ) ty2) =
+subConstraints (SubType _ ty1@TyVar {} ty2) =
   throwSolverError ["subConstraints should only be called if neither upper nor lower bound are unification variables"
                    , ppPrint ty1
                    , "<:"
                    , ppPrint ty2
                    ]
-subConstraints (SubType _ ty1 ty2@(TyVar _ _ _ _)) =
+subConstraints (SubType _ ty1 ty2@TyVar {}) =
   throwSolverError ["subConstraints should only be called if neither upper nor lower bound are unification variables"
                    , ppPrint ty1
                    , "<:"

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -16,9 +16,9 @@ import Text.Megaparsec.Pos
 data Loc = Loc SourcePos SourcePos
   deriving (Eq, Ord)
 
-instance Show Loc where 
+instance Show Loc where
   show (Loc _s1 _s2) = "<loc>"
-  
+
 defaultLoc :: Loc
 defaultLoc = Loc (SourcePos "" (mkPos 1) (mkPos 1)) (SourcePos "" (mkPos 1) (mkPos 1))
 
@@ -34,7 +34,7 @@ intersections :: Ord a => NonEmpty (Set a) -> Set a
 intersections (s :| ss) = foldl' S.intersection s ss
 
 enumerate :: [a] -> [(Int,a)]
-enumerate xs = zip [0..] xs
+enumerate = zip [0..]
 
 trimStr :: String -> String
 trimStr = f . f
@@ -46,7 +46,7 @@ trim = f . f
 
 
 indexMaybe :: [a] -> Int -> Maybe a
-indexMaybe xs i | 0 <= i && i <= (length xs) -1 = Just (xs !! i)
+indexMaybe xs i | 0 <= i && i <= length xs -1 = Just (xs !! i)
                 | otherwise = Nothing
 
 data Verbosity = Verbose | Silent

--- a/test/Spec/Prettyprinter.hs
+++ b/test/Spec/Prettyprinter.hs
@@ -27,14 +27,14 @@ spec examples = do
         it "Can be parsed again." $
           case prog of
             Left err -> expectationFailure (ppPrintString err)
-            Right decls -> (runFileParser example programP (ppPrint decls)) `shouldSatisfy` isRight
+            Right decls -> runFileParser example programP (ppPrint decls) `shouldSatisfy` isRight
   
   describe "All the examples in the \"examples/\" folder can be parsed and typechecked after prettyprinting." $ do
     forM_ examples $ \(example,prog) -> do
       describe ("The example " ++ example ++ " can be parsed and typechecked after prettyprinting.") $ do
         case prog of 
             Left err -> it "Can be parsed and typechecked again." $ expectationFailure (ppPrintString err)
-            Right decls -> case (runFileParser example programP (ppPrint decls)) of
+            Right decls -> case runFileParser example programP (ppPrint decls) of
               Left _ -> it "Can be parsed and typechecked again." $ expectationFailure "Could not be parsed"
               Right decls -> do
                 res <- runIO $ inferProgramIO defaultDriverState (MkModuleName "") decls


### PR DESCRIPTION
Apply some hlint suggestions:
 - remove redundant brackets
 - eta reduction
 - record wildcards
 - higher order functions instead of lambdas, e.g. from `Data.Bifunctor`
 - use `newtype` instead of `data`