### PR TITLE
Parameterise Bisubstitutions by VarType

### DIFF
--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -92,7 +92,7 @@ inferPrdCnsDeclaration mn Core.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcd
   let bisubst = coalesce solverResult
   guardVerbose $ ppPrintIO bisubst
   -- 4. Read of the type and generate the resulting type
-  let typ = zonk bisubst (TST.getTypeTerm tmInferred)
+  let typ = zonk UniRep bisubst (TST.getTypeTerm tmInferred)
   guardVerbose $ putStr "\nInferred type: " >> ppPrintIO typ >> putStrLn ""
   -- 5. Simplify
   typSimplified <- if infOptsSimplify infopts then (do

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -139,7 +139,7 @@ instance PrettyAnn (Bisubstitution UniVT) where
 instance PrettyAnn (Bisubstitution SkolemVT) where
   prettyAnn uvsubst = vsep
     [ "---------------------------------------------------------"
-    , "                 Bisubstitution (UniTVar)                "
+    , "                 Bisubstitution (SkolemTVar)             "
     , "---------------------------------------------------------"
     , ""
     , vsep $ intersperse "" (prettyRecBisubst <$> M.toList (bisubst_map uvsubst))

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -127,13 +127,20 @@ prettyRecBisubst (v, (typ,tyn)) = nest 3 $ vsep ["Skolem variable:" <+> prettyAn
                                                     ]
                                              ]
 
-instance PrettyAnn Bisubstitution where
-  prettyAnn (MkBisubstitution uvsubst recsubst) = vsep
+instance PrettyAnn (Bisubstitution UniVT) where
+  prettyAnn uvsubst = vsep
     [ "---------------------------------------------------------"
-    , "                 Bisubstitution                          "
+    , "                 Bisubstitution (UniTVar)                "
     , "---------------------------------------------------------"
     , ""
-    , vsep $ intersperse "" (prettyBisubst <$> M.toList uvsubst)
+    , vsep $ intersperse "" (prettyBisubst <$> M.toList (bisubst_map uvsubst))
+    ]
+
+instance PrettyAnn (Bisubstitution SkolemVT) where
+  prettyAnn uvsubst = vsep
+    [ "---------------------------------------------------------"
+    , "                 Bisubstitution (UniTVar)                "
     , "---------------------------------------------------------"
-    , vsep $ intersperse "" (prettyRecBisubst <$> M.toList recsubst)
+    , ""
+    , vsep $ intersperse "" (prettyRecBisubst <$> M.toList (bisubst_map uvsubst))
     ]

--- a/src/Syntax/Common/TypesPol.hs
+++ b/src/Syntax/Common/TypesPol.hs
@@ -194,69 +194,85 @@ generalize ty = TypeScheme defaultLoc (S.toList (freeTVars ty)) ty
 -- Bisubstitution and Zonking
 ------------------------------------------------------------------------------
 
-data Bisubstitution = MkBisubstitution { uvarSubst :: Map UniTVar (Typ Pos, Typ Neg), recvarSubst :: Map SkolemTVar (Typ Pos, Typ Neg) }
+data VarType
+  = UniVT
+  | SkolemVT
+
+type family BisubstMap (vt :: VarType) :: Type where
+  BisubstMap UniVT    = Map UniTVar (Typ Pos, Typ Neg)
+  BisubstMap SkolemVT = Map SkolemTVar (Typ Pos, Typ Neg)
+
+newtype Bisubstitution vt = MkBisubstitution { bisubst_map :: BisubstMap vt }
+
+data VarTypeRep (vt :: VarType) where
+  UniRep    :: VarTypeRep UniVT
+  SkolemRep :: VarTypeRep SkolemVT
 
 -- | Class of types for which a Bisubstitution can be applied.
 class Zonk (a :: Type) where
-  zonk :: Bisubstitution -> a -> a
+  zonk :: VarTypeRep vt -> Bisubstitution vt -> a -> a
 
 instance Zonk (Typ pol) where
-  zonk bisubst ty@(TyUniVar _ PosRep _ tv) = case M.lookup tv (uvarSubst bisubst) of
+  zonk UniRep bisubst ty@(TyUniVar _ PosRep _ tv) = case M.lookup tv (bisubst_map bisubst) of
      Nothing -> ty -- Recursive variable!
      Just (tyPos,_) -> tyPos
-  zonk bisubst ty@(TyUniVar _ NegRep _ tv) = case M.lookup tv (uvarSubst bisubst) of
+  zonk SkolemRep _bisubst ty@(TyUniVar _ PosRep _ _) = ty
+  zonk UniRep bisubst ty@(TyUniVar _ NegRep _ tv) = case M.lookup tv (bisubst_map bisubst) of
      Nothing -> ty -- Recursive variable!
      Just (_,tyNeg) -> tyNeg
-  zonk bisubst ty@(TySkolemVar _ NegRep _ tv) = case M.lookup tv (recvarSubst bisubst) of
-     Nothing -> ty -- Recursive variable!
-     Just (_,tyNeg) -> tyNeg
-  zonk bisubst ty@(TySkolemVar _ PosRep _ tv) = case M.lookup tv (recvarSubst bisubst) of
+  zonk SkolemRep _bisubst ty@(TyUniVar _ NegRep _ _) = ty
+  zonk UniRep _bisubst ty@(TySkolemVar _ PosRep _ _) = ty
+  zonk SkolemRep bisubst ty@(TySkolemVar _ PosRep _ tv) = case M.lookup tv (bisubst_map bisubst) of
      Nothing -> ty -- Recursive variable!
      Just (tyPos,_) -> tyPos
-  zonk bisubst (TyData loc rep xtors) =
-     TyData loc rep (zonk bisubst <$> xtors)
-  zonk bisubst (TyCodata loc rep xtors) =
-     TyCodata loc rep (zonk bisubst <$> xtors)
-  zonk bisubst (TyDataRefined loc rep tn xtors) =
-     TyDataRefined loc rep tn (zonk bisubst <$> xtors)
-  zonk bisubst (TyCodataRefined loc rep tn xtors) =
-     TyCodataRefined loc rep tn (zonk bisubst <$> xtors)
-  zonk bisubst (TyNominal loc rep kind tn args) =
-     TyNominal loc rep kind tn (zonk bisubst <$> args)
-  zonk bisubst (TySyn loc rep nm ty) =
-     TySyn loc rep nm (zonk bisubst ty)
-  zonk _ (TyTop loc knd) =
+  zonk UniRep _bisubst ty@(TySkolemVar _ NegRep _ _v) = ty
+  zonk SkolemRep bisubst ty@(TySkolemVar _ NegRep _ tv) = case M.lookup tv (bisubst_map bisubst) of
+     Nothing -> ty -- Recursive variable!
+     Just (_,tyNeg) -> tyNeg
+  zonk vt bisubst (TyData loc rep xtors) =
+     TyData loc rep (zonk vt bisubst <$> xtors)
+  zonk vt bisubst (TyCodata loc rep xtors) =
+     TyCodata loc rep (zonk vt bisubst <$> xtors)
+  zonk vt bisubst (TyDataRefined loc rep tn xtors) =
+     TyDataRefined loc rep tn (zonk vt bisubst <$> xtors)
+  zonk vt bisubst (TyCodataRefined loc rep tn xtors) =
+     TyCodataRefined loc rep tn (zonk vt bisubst <$> xtors)
+  zonk vt bisubst (TyNominal loc rep kind tn args) =
+     TyNominal loc rep kind tn (zonk vt bisubst <$> args)
+  zonk vt bisubst (TySyn loc rep nm ty) =
+     TySyn loc rep nm (zonk vt bisubst ty)
+  zonk _vt _ (TyTop loc knd) =
     TyTop loc knd
-  zonk _ (TyBot loc knd) =
+  zonk _vt _ (TyBot loc knd) =
     TyBot loc knd
-  zonk bisubst (TyUnion loc knd ty ty') =
-    TyUnion loc knd (zonk bisubst ty) (zonk bisubst ty')
-  zonk bisubst (TyInter loc knd ty ty') =
-    TyInter loc knd (zonk bisubst ty) (zonk bisubst ty')
-  zonk bisubst (TyRec loc rep tv ty) =
-     TyRec loc rep tv (zonk bisubst ty)
-  zonk _ t@TyPrim {} = t
-  zonk bisubst (TyFlipPol rep ty) = TyFlipPol rep (zonk bisubst ty)
+  zonk vt bisubst (TyUnion loc knd ty ty') =
+    TyUnion loc knd (zonk vt bisubst ty) (zonk vt bisubst ty')
+  zonk vt bisubst (TyInter loc knd ty ty') =
+    TyInter loc knd (zonk vt bisubst ty) (zonk vt bisubst ty')
+  zonk vt bisubst (TyRec loc rep tv ty) =
+     TyRec loc rep tv (zonk vt bisubst ty)
+  zonk _vt _ t@TyPrim {} = t
+  zonk vt bisubst (TyFlipPol rep ty) = TyFlipPol rep (zonk vt bisubst ty)
 
 instance Zonk (VariantType pol) where
-  zonk bisubst (CovariantType ty) = CovariantType (zonk bisubst ty)
-  zonk bisubst (ContravariantType ty) = ContravariantType (zonk bisubst ty)
+  zonk vt bisubst (CovariantType ty) = CovariantType (zonk vt bisubst ty)
+  zonk vt bisubst (ContravariantType ty) = ContravariantType (zonk vt bisubst ty)
 
 instance Zonk (XtorSig pol) where
-  zonk bisubst (MkXtorSig name ctxt) =
-    MkXtorSig name (zonk bisubst ctxt)
+  zonk vt bisubst (MkXtorSig name ctxt) =
+    MkXtorSig name (zonk vt bisubst ctxt)
 
 instance Zonk (LinearContext pol) where
-  zonk bisubst = fmap (zonk bisubst)
+  zonk vt bisubst = fmap (zonk vt bisubst)
 
 instance Zonk (PrdCnsType pol) where
-  zonk bisubst (PrdCnsType rep ty) = PrdCnsType rep (zonk bisubst ty)
+  zonk vt bisubst (PrdCnsType rep ty) = PrdCnsType rep (zonk vt bisubst ty)
 
 
 -- This is probably not 100% correct w.r.t alpha-renaming. Postponed until we have a better repr. of types.
 unfoldRecType :: Typ pol -> Typ pol
-unfoldRecType recty@(TyRec _ PosRep var ty) = zonk (MkBisubstitution M.empty (M.fromList [(var,(recty, error "unfoldRecType"))])) ty
-unfoldRecType recty@(TyRec _ NegRep var ty) = zonk (MkBisubstitution M.empty (M.fromList [(var,(error "unfoldRecType", recty))])) ty
+unfoldRecType recty@(TyRec _ PosRep var ty) = zonk SkolemRep (MkBisubstitution (M.fromList [(var,(recty, error "unfoldRecType"))])) ty
+unfoldRecType recty@(TyRec _ NegRep var ty) = zonk SkolemRep (MkBisubstitution (M.fromList [(var,(error "unfoldRecType", recty))])) ty
 unfoldRecType ty = ty
 
 ------------------------------------------------------------------------------

--- a/src/Syntax/TST/Terms.hs
+++ b/src/Syntax/TST/Terms.hs
@@ -51,8 +51,8 @@ data PrdCnsTerm where
 deriving instance Show PrdCnsTerm
 
 instance Zonk PrdCnsTerm where
-  zonk bisubst (PrdTerm tm) = PrdTerm (zonk bisubst tm)
-  zonk bisubst (CnsTerm tm) = CnsTerm (zonk bisubst tm)
+  zonk vt bisubst (PrdTerm tm) = PrdTerm (zonk vt bisubst tm)
+  zonk vt bisubst (CnsTerm tm) = CnsTerm (zonk vt bisubst tm)
 
 type Substitution = [PrdCnsTerm]
 
@@ -71,8 +71,8 @@ data CmdCase = MkCmdCase
   }
 
 instance Zonk CmdCase where
-  zonk bisubst (MkCmdCase loc pat cmd) =
-    MkCmdCase loc pat (zonk bisubst cmd)
+  zonk vt bisubst (MkCmdCase loc pat cmd) =
+    MkCmdCase loc pat (zonk vt bisubst cmd)
 
 deriving instance Show CmdCase
 
@@ -128,19 +128,19 @@ deriving instance Show (Term pc)
 
 instance Zonk (Term pc) where
   -- Core constructs
-  zonk bisubst (BoundVar loc rep ty idx) =
-    BoundVar loc rep (zonk bisubst ty) idx
-  zonk bisubst (FreeVar loc rep ty nm)  =
-    FreeVar loc rep (zonk bisubst ty) nm
-  zonk bisubst (Xtor loc annot rep ty ns xt subst) =
-    Xtor loc annot rep (zonk bisubst ty) ns xt (zonk bisubst <$> subst)
-  zonk bisubst (XCase loc annot rep ty ns cases) =
-    XCase loc annot rep (zonk bisubst ty) ns (zonk bisubst <$> cases)
-  zonk bisubst (MuAbs loc annot rep ty fv cmd) =
-    MuAbs loc annot rep (zonk bisubst ty) fv (zonk bisubst cmd)
+  zonk vt bisubst (BoundVar loc rep ty idx) =
+    BoundVar loc rep (zonk vt bisubst ty) idx
+  zonk vt bisubst (FreeVar loc rep ty nm)  =
+    FreeVar loc rep (zonk vt bisubst ty) nm
+  zonk vt bisubst (Xtor loc annot rep ty ns xt subst) =
+    Xtor loc annot rep (zonk vt bisubst ty) ns xt (zonk vt bisubst <$> subst)
+  zonk vt bisubst (XCase loc annot rep ty ns cases) =
+    XCase loc annot rep (zonk vt bisubst ty) ns (zonk vt bisubst <$> cases)
+  zonk vt bisubst (MuAbs loc annot rep ty fv cmd) =
+    MuAbs loc annot rep (zonk vt bisubst ty) fv (zonk vt bisubst cmd)
   -- Primitive constructs  
-  zonk _ lit@PrimLitI64{} = lit
-  zonk _ lit@PrimLitF64{} = lit
+  zonk _vt _ lit@PrimLitI64{} = lit
+  zonk _vt _ lit@PrimLitF64{} = lit
 
 getTypeTerm :: forall pc. Term pc -> Typ (PrdCnsToPol pc)
 -- Core constructs
@@ -180,20 +180,20 @@ data Command where
 deriving instance Show Command
 
 instance Zonk Command where
-  zonk bisubst (Apply ext annot kind prd cns) =
-    Apply ext annot kind (zonk bisubst prd) (zonk bisubst cns)
-  zonk bisubst (Print ext prd cmd) =
-    Print ext (zonk bisubst prd) (zonk bisubst cmd)
-  zonk bisubst (Read ext cns) =
-    Read ext (zonk bisubst cns)
-  zonk _ (Jump ext fv) =
+  zonk vt bisubst (Apply ext annot kind prd cns) =
+    Apply ext annot kind (zonk vt bisubst prd) (zonk vt bisubst cns)
+  zonk vt bisubst (Print ext prd cmd) =
+    Print ext (zonk vt bisubst prd) (zonk vt bisubst cmd)
+  zonk vt bisubst (Read ext cns) =
+    Read ext (zonk vt bisubst cns)
+  zonk _vt _ (Jump ext fv) =
     Jump ext fv
-  zonk _ (ExitSuccess ext) =
+  zonk _vt _ (ExitSuccess ext) =
     ExitSuccess ext
-  zonk _ (ExitFailure ext) =
+  zonk _vt _ (ExitFailure ext) =
     ExitFailure ext
-  zonk bisubst (PrimOp ext pt op subst) =
-    PrimOp ext pt op (zonk bisubst <$> subst)
+  zonk vt bisubst (PrimOp ext pt op subst) =
+    PrimOp ext pt op (zonk vt bisubst <$> subst)
 
 ---------------------------------------------------------------------------------
 -- Variable Opening

--- a/src/TypeInference/Coalescing.hs
+++ b/src/TypeInference/Coalescing.hs
@@ -53,8 +53,8 @@ getOrElseUpdateRecVar ptv = do
           return recVar
       Just tv -> return tv
 
-coalesce :: SolverResult -> Bisubstitution
-coalesce result@MkSolverResult { tvarSolution } = MkBisubstitution (M.fromList xs) M.empty
+coalesce :: SolverResult -> Bisubstitution UniVT
+coalesce result@MkSolverResult { tvarSolution } = MkBisubstitution $ M.fromList xs
     where
         res = M.keys tvarSolution
         f tvar = do x <- coalesceType $ TyUniVar defaultLoc PosRep Nothing tvar

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -109,7 +109,7 @@ genConstraintsTerm (Core.Xtor loc annot rep Nominal xt subst) = do
   -- Generate fresh unification variables for type parameters
   (args, tyParamsMap) <- freshTVarsForTypeParams (prdCnsToPol rep) decl
   -- Substitute these for the type parameters in the constructor signature
-  let sig_args' = zonk tyParamsMap (sig_args xtorSig)
+  let sig_args' = zonk SkolemRep tyParamsMap (sig_args xtorSig)
   -- Then we generate constraints between the inferred types of the substitution
   -- and the types we looked up, i.e. the types declared in the XtorSig.
   genConstraintsCtxts substTypes sig_args' (case rep of { PrdRep -> CtorArgsConstraint loc; CnsRep -> DtorArgsConstraint loc })
@@ -171,8 +171,8 @@ genConstraintsTerm (Core.XCase loc annot rep Nominal cases@(pmcase:_)) = do
                    posTypes <- sig_args <$> lookupXtorSig xt PosRep
                    negTypes <- sig_args <$> lookupXtorSig xt NegRep
                    -- Substitute fresh unification variables for type parameters
-                   let posTypes' = zonk tyParamsMap posTypes
-                   let negTypes' = zonk tyParamsMap negTypes
+                   let posTypes' = zonk SkolemRep tyParamsMap posTypes
+                   let negTypes' = zonk SkolemRep tyParamsMap negTypes
                    -- We generate constraints for the command in the context extended
                    -- with the types from the signature.
                    cmdInferred <- withContext posTypes' (genConstraintsCommand cmdcase_cmd)
@@ -270,8 +270,8 @@ genConstraintsInstance Core.MkInstanceDeclaration { instancedecl_loc, instancede
                    posTypes <- lookupMethodType xt decl PosRep
                    negTypes <- lookupMethodType xt decl NegRep
                    -- Substitute fresh unification variables for type parameters
-                   let posTypes' = zonk tyParamsMap posTypes
-                   let negTypes' = zonk tyParamsMap negTypes
+                   let posTypes' = zonk SkolemRep tyParamsMap posTypes
+                   let negTypes' = zonk SkolemRep tyParamsMap negTypes
                    -- We generate constraints for the command in the context extended
                    -- with the types from the signature.
                    cmdInferred <- withContext posTypes' (genConstraintsCommand instancecase_cmd)


### PR DESCRIPTION
Bisubstitions are only ever used to substitute _either_ `UniTVar`s _or_ `SkolemTVar`s (and `RecTVar`s, once they are added).
This change will make this explicit
