### PR TITLE
deduplicate failed tests

### DIFF
--- a/test/Spec/TypeInferenceExamples.hs
+++ b/test/Spec/TypeInferenceExamples.hs
@@ -16,16 +16,10 @@ pendingFiles = [ ("examples/TypeClasses.duo", "Backend not implemented for type 
                ]
 
 -- | Typecheck the programs in the toplevel "examples/" subfolder.
-spec :: [(FilePath, Either (NonEmpty Error) TST.Program)] -- ^ examples
-     -> [(FilePath, Either (NonEmpty Error) CST.Program)]
+spec :: [(FilePath, Either (NonEmpty Error) CST.Program)]
      -> [(FilePath, Either (NonEmpty Error) TST.Program)]
      -> Spec
-spec examples counterExamplesParsed counterExamplesChecked = do
-  describe "All the programs in the toplevel \"examples/\" folder typecheck." $ do
-    forM_ examples $ \(example, prog) -> do
-      case example `lookup` pendingFiles of
-         Just reason -> it "" $ pendingWith $ "Could not focus file " ++ example ++ "\nReason: " ++ reason
-         Nothing     -> it ("The file " ++ example ++ " typechecks.") $ prog `shouldSatisfy` isRight
+spec counterExamplesParsed counterExamplesChecked = do
   describe "All the programs in the \"test/counterexamples/\" folder can be parsed." $ do
     forM_ counterExamplesParsed $ \(example, prog) -> do
       describe ("The counterexample " ++ example ++ " can be parsed") $ do

--- a/test/TestRunner.hs
+++ b/test/TestRunner.hs
@@ -112,7 +112,7 @@ main = do
     -- Run the testsuite
     withArgs [] $ hspecWith defaultConfig { configFormatter = Just specdoc } $ do
       describe "All examples are locally closed" (Spec.LocallyClosed.spec checkedExamples)
-      describe "ExampleSpec" (Spec.TypeInferenceExamples.spec checkedExamplesFiltered parsedCounterExamples checkedCounterExamples)
+      describe "ExampleSpec" (Spec.TypeInferenceExamples.spec parsedCounterExamples checkedCounterExamples)
       describe "Subsumption works" (Spec.Subsumption.spec symboltables)
       describe "Prettyprinted work again" (Spec.Prettyprinter.spec parsedExamples checkedExamplesFiltered)
       describe "Focusing works" (Spec.Focusing.spec checkedExamplesFiltered)


### PR DESCRIPTION
Since several tests use typechecked programs as inputs, failed typechecking will result in all those tests failing with the same error message which was created by the typechecking.
To avoid this duplications, these test will no longer be run on programs that did not typecheck.
