### PR TITLE
Structure constraint generation errors

### DIFF
--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -92,7 +92,7 @@ data ConstraintGenerationError where
   EmptyRefinementMatch :: Loc -> ConstraintGenerationError
   -- | Linear contexts have unequal length.
   LinearContextsUnequalLength :: Loc -> ConstraintInfo -> LinearContext Pos -> LinearContext Neg -> ConstraintGenerationError
-  LinearContextIncompatibleTypeMode :: Loc -> ConstraintInfo -> ConstraintGenerationError
+  LinearContextIncompatibleTypeMode :: Loc -> PrdCns -> ConstraintInfo -> ConstraintGenerationError
 
 
 deriving instance Show ConstraintGenerationError
@@ -108,7 +108,7 @@ instance HasLoc ConstraintGenerationError where
   getLoc (EmptyNominalMatch loc) = loc
   getLoc (EmptyRefinementMatch loc) = loc
   getLoc (LinearContextsUnequalLength loc _ _ _) = loc
-  getLoc (LinearContextIncompatibleTypeMode loc _) = loc
+  getLoc (LinearContextIncompatibleTypeMode loc _ _) = loc
 
 instance AttachLoc ConstraintGenerationError where
   attachLoc loc (BoundVariableOutOfBounds _ pc idx) = BoundVariableOutOfBounds loc pc idx
@@ -121,7 +121,7 @@ instance AttachLoc ConstraintGenerationError where
   attachLoc loc (EmptyNominalMatch _) = EmptyNominalMatch loc
   attachLoc loc (EmptyRefinementMatch _) = EmptyRefinementMatch loc
   attachLoc loc (LinearContextsUnequalLength _ ci ctx1 ctx2) = LinearContextsUnequalLength loc ci ctx1 ctx2
-  attachLoc loc (LinearContextIncompatibleTypeMode _ ci) = LinearContextIncompatibleTypeMode loc ci
+  attachLoc loc (LinearContextIncompatibleTypeMode _ pc ci) = LinearContextIncompatibleTypeMode loc pc ci
 
 
 ----------------------------------------------------------------------------------

--- a/src/Errors.hs
+++ b/src/Errors.hs
@@ -7,7 +7,9 @@ import Data.Text (Text)
 import Data.Text qualified as T
 
 import Syntax.Common
+import Syntax.Common.TypesPol
 import Utils
+import TypeInference.Constraints (ConstraintInfo)
 
 ----------------------------------------------------------------------------------
 -- Errors emitted during the resolution phase
@@ -70,17 +72,57 @@ instance AttachLoc ResolutionError where
 ----------------------------------------------------------------------------------
 
 data ConstraintGenerationError where
-  SomeConstraintGenerationError :: Loc -> Text -> ConstraintGenerationError
+  -- | A bound variable is not bound in the context. (Likely implementation error).
+  BoundVariableOutOfBounds :: Loc -> PrdCns -> Index -> ConstraintGenerationError
+  -- | A bound variable is used with the wrong mode (Prd/Cns).
+  BoundVariableWrongMode :: Loc -> PrdCns -> Index -> ConstraintGenerationError
+  -- | A pattern match fails to match on given constructor/destructor.
+  PatternMatchMissingXtor :: Loc -> XtorName -> RnTypeName -> ConstraintGenerationError
+  -- | A pattern match tries to match on a constructor/destructor not contained in declaration.
+  PatternMatchAdditional :: Loc -> XtorName -> RnTypeName -> ConstraintGenerationError
+  -- | Typeclass method contained in class declaration, but missing in instance implementation.
+  InstanceImplementationMissing :: Loc -> MethodName -> ConstraintGenerationError
+  -- | Typeclass method implemented in instance, but not contained in class declaration.
+  InstanceImplementationAdditional :: Loc -> MethodName -> ConstraintGenerationError
+  -- | Could not find signature for given primitive operation.
+  PrimitiveOpMissingSignature :: Loc -> PrimitiveOp -> PrimitiveType -> ConstraintGenerationError
+  -- | One cannot infer a type for an empty nominal match.
+  EmptyNominalMatch :: Loc -> ConstraintGenerationError
+  -- | One cannot infer a type for an empty refinement match.
+  EmptyRefinementMatch :: Loc -> ConstraintGenerationError
+  -- | Linear contexts have unequal length.
+  LinearContextsUnequalLength :: Loc -> ConstraintInfo -> LinearContext Pos -> LinearContext Neg -> ConstraintGenerationError
+  LinearContextIncompatibleTypeMode :: Loc -> ConstraintInfo -> ConstraintGenerationError
+
 
 deriving instance Show ConstraintGenerationError
 
 instance HasLoc ConstraintGenerationError where
-  getLoc (SomeConstraintGenerationError loc _) =
-    loc
+  getLoc (BoundVariableOutOfBounds loc _ _) = loc
+  getLoc (BoundVariableWrongMode loc _ _) = loc
+  getLoc (PatternMatchMissingXtor loc _ _) = loc
+  getLoc (PatternMatchAdditional loc _ _) = loc
+  getLoc (InstanceImplementationMissing loc _) = loc
+  getLoc (InstanceImplementationAdditional loc _) = loc
+  getLoc (PrimitiveOpMissingSignature loc _ _) = loc
+  getLoc (EmptyNominalMatch loc) = loc
+  getLoc (EmptyRefinementMatch loc) = loc
+  getLoc (LinearContextsUnequalLength loc _ _ _) = loc
+  getLoc (LinearContextIncompatibleTypeMode loc _) = loc
 
 instance AttachLoc ConstraintGenerationError where
-  attachLoc loc (SomeConstraintGenerationError _ msg) =
-    SomeConstraintGenerationError loc msg
+  attachLoc loc (BoundVariableOutOfBounds _ pc idx) = BoundVariableOutOfBounds loc pc idx
+  attachLoc loc (BoundVariableWrongMode _ pc idx) = BoundVariableWrongMode loc pc idx
+  attachLoc loc (PatternMatchMissingXtor _ xn tn)  = PatternMatchMissingXtor loc xn tn
+  attachLoc loc (PatternMatchAdditional _ xn tn) = PatternMatchAdditional loc xn tn
+  attachLoc loc (InstanceImplementationMissing _ mn) = InstanceImplementationMissing loc mn
+  attachLoc loc (InstanceImplementationAdditional _ mn) = InstanceImplementationAdditional loc mn
+  attachLoc loc (PrimitiveOpMissingSignature _ po pt) = PrimitiveOpMissingSignature loc po pt
+  attachLoc loc (EmptyNominalMatch _) = EmptyNominalMatch loc
+  attachLoc loc (EmptyRefinementMatch _) = EmptyRefinementMatch loc
+  attachLoc loc (LinearContextsUnequalLength _ ci ctx1 ctx2) = LinearContextsUnequalLength loc ci ctx1 ctx2
+  attachLoc loc (LinearContextIncompatibleTypeMode _ ci) = LinearContextIncompatibleTypeMode loc ci
+
 
 ----------------------------------------------------------------------------------
 -- Errors emitted during the constraint solving phase
@@ -204,9 +246,9 @@ instance AttachLoc Error where
 ---------------------------------------------------------------------------------------------
 
 throwGenError :: MonadError (NonEmpty Error) m
-              => Loc -> [Text] -> m a
-throwGenError loc =
-  throwError . (NE.:| []) . (ErrConstraintGeneration . SomeConstraintGenerationError loc) . T.unlines
+              => ConstraintGenerationError -> m a
+throwGenError  =
+  throwError . (NE.:| []) . ErrConstraintGeneration
 
 throwEvalError :: MonadError (NonEmpty Error) m
                => Loc -> [Text] -> m a

--- a/src/Pretty/Errors.hs
+++ b/src/Pretty/Errors.hs
@@ -62,8 +62,17 @@ instance PrettyAnn ResolutionError where
     prettyAnn loc <+> "Invalid Star: " <+> pretty t
 
 instance PrettyAnn ConstraintGenerationError where
-  prettyAnn (SomeConstraintGenerationError loc msg) =
-    prettyAnn loc <> "Constraint generation error:" <+> pretty msg
+  prettyAnn (BoundVariableOutOfBounds _ _ _) = "undefined"
+  prettyAnn (BoundVariableWrongMode _ _ _) = "undefined"
+  prettyAnn (PatternMatchMissingXtor _ _ _) = "undefined"
+  prettyAnn (PatternMatchAdditional _ _ _) = "undefined"
+  prettyAnn (InstanceImplementationMissing _ _) = "undefined"
+  prettyAnn (InstanceImplementationAdditional _ _) = "undefined"
+  prettyAnn (PrimitiveOpMissingSignature _ _ _) = "undefined"
+  prettyAnn (EmptyNominalMatch _) = "undefined"
+  prettyAnn (EmptyRefinementMatch _) = "undefined"
+  prettyAnn (LinearContextsUnequalLength _ _ _ _) = "undefined"
+  prettyAnn (LinearContextIncompatibleTypeMode _ _) = "undefined"
 
 instance PrettyAnn ConstraintSolverError where
   prettyAnn (SomeConstraintSolverError loc msg) =
@@ -133,8 +142,28 @@ instance ToReport ResolutionError where
     err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
 
 instance ToReport ConstraintGenerationError where
-  toReport (SomeConstraintGenerationError loc msg) =
-    err (Just "E-000") msg [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(BoundVariableOutOfBounds loc _ _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(BoundVariableWrongMode loc _ _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(PatternMatchMissingXtor loc _ _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(PatternMatchAdditional loc _ _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(InstanceImplementationMissing loc _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(InstanceImplementationAdditional loc _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(PrimitiveOpMissingSignature loc _ _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(EmptyNominalMatch loc) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(EmptyRefinementMatch loc) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(LinearContextsUnequalLength loc _ _ _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
+  toReport e@(LinearContextIncompatibleTypeMode loc _) =
+    err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
 
 instance ToReport ConstraintSolverError where
   toReport (SomeConstraintSolverError loc msg) =

--- a/src/Pretty/Errors.hs
+++ b/src/Pretty/Errors.hs
@@ -22,6 +22,7 @@ import Pretty.Pretty ( PrettyAnn(..), ppPrint )
 import Syntax.Common.Primitives ( primTypeKeyword, primOpKeyword )
 import Utils (Loc (Loc), HasLoc (getLoc))
 import Text.Megaparsec (SourcePos(..), unPos)
+import Syntax.Common (PrdCns(..))
 
 ---------------------------------------------------------------------------------
 -- Prettyprinting of Errors
@@ -62,17 +63,67 @@ instance PrettyAnn ResolutionError where
     prettyAnn loc <+> "Invalid Star: " <+> pretty t
 
 instance PrettyAnn ConstraintGenerationError where
-  prettyAnn (BoundVariableOutOfBounds _ _ _) = "undefined"
-  prettyAnn (BoundVariableWrongMode _ _ _) = "undefined"
-  prettyAnn (PatternMatchMissingXtor _ _ _) = "undefined"
-  prettyAnn (PatternMatchAdditional _ _ _) = "undefined"
-  prettyAnn (InstanceImplementationMissing _ _) = "undefined"
-  prettyAnn (InstanceImplementationAdditional _ _) = "undefined"
-  prettyAnn (PrimitiveOpMissingSignature _ _ _) = "undefined"
-  prettyAnn (EmptyNominalMatch _) = "undefined"
-  prettyAnn (EmptyRefinementMatch _) = "undefined"
-  prettyAnn (LinearContextsUnequalLength _ _ _ _) = "undefined"
-  prettyAnn (LinearContextIncompatibleTypeMode _ _) = "undefined"
+  prettyAnn (BoundVariableOutOfBounds loc rep (i,j)) =
+    vsep [ prettyAnn loc
+         , "Bound Variable out of bounds:"
+         , "PrdCns:" <+> pretty (show rep)
+         , "Index:" <+> pretty (show (i,j))
+         ]
+  prettyAnn (BoundVariableWrongMode loc Prd (i,j)) = 
+    vsep [ prettyAnn loc
+         , "Bound Variable" <+> pretty (show (i,j)) <+> "was expected to be PrdType, but CnsType was found."
+         ]
+  prettyAnn (BoundVariableWrongMode loc Cns (i,j)) = 
+    vsep [ prettyAnn loc
+         , "Bound Variable" <+> pretty (show (i,j)) <+> "was expected to be CnsType, but PrdType was found."
+         ]
+  prettyAnn (PatternMatchMissingXtor loc xn tn) =
+    vsep [ prettyAnn loc
+         , "Pattern Match Exhaustiveness Error. Xtor:" <+> prettyAnn xn <+> "of type" <+> prettyAnn tn <+> "is not matched against."
+         ]
+    
+  prettyAnn (PatternMatchAdditional loc xn tn) =
+    vsep [ prettyAnn loc
+         , "Pattern Match Error. The xtor" <+> prettyAnn xn <+> "does not occur in the declaration of type" <+> prettyAnn tn
+         ]
+  prettyAnn (InstanceImplementationMissing loc m) =
+    vsep [ prettyAnn loc
+         , "Instance Declaration Error. Method: " <> prettyAnn m <> " is declared but not implemented."
+         ]
+  prettyAnn (InstanceImplementationAdditional loc m) =
+    vsep [ prettyAnn loc
+         , "Instance Declaration Error. Method: " <> prettyAnn m <> " is implemented but not declared."
+         ]
+  prettyAnn (PrimitiveOpMissingSignature loc op pt) =
+    vsep [ prettyAnn loc
+         , "Unreachable: Signature for primitive op" <+> pretty (primOpKeyword op) <> pretty (primTypeKeyword pt) <+> "not defined"
+         ]
+  prettyAnn (EmptyNominalMatch loc) =
+    vsep [ prettyAnn loc
+         , "Unreachable: A nominal match needs to have at least one case."
+         ]
+  prettyAnn (EmptyRefinementMatch loc) =
+    vsep [ prettyAnn loc
+         , "Unreachable: A refinement match needs to have at least one case."
+         ]
+  prettyAnn (LinearContextsUnequalLength loc info ctx1 ctx2) =
+    vsep [ prettyAnn loc
+         , "genConstraintsCtxts: Linear contexts have unequal length"
+         , "Constraint Info: " <> prettyAnn info
+         , "Pos context: " <> prettyAnn ctx1
+         , "Neg context: " <> prettyAnn ctx2
+         ]
+  prettyAnn (LinearContextIncompatibleTypeMode loc Prd info) =
+    vsep [ prettyAnn loc
+         , "genConstraintsCtxts: Tried to constrain PrdType by CnsType"
+         , "Constraint Info:" <+> prettyAnn info
+         ]
+  prettyAnn (LinearContextIncompatibleTypeMode loc Cns info) =
+    vsep [ prettyAnn loc
+         , "genConstraintsCtxts: Tried to constrain CnsType by PrdType"
+         , "Constraint Info:" <+> prettyAnn info
+         ]
+    
 
 instance PrettyAnn ConstraintSolverError where
   prettyAnn (SomeConstraintSolverError loc msg) =
@@ -162,7 +213,7 @@ instance ToReport ConstraintGenerationError where
     err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
   toReport e@(LinearContextsUnequalLength loc _ _ _) =
     err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
-  toReport e@(LinearContextIncompatibleTypeMode loc _) =
+  toReport e@(LinearContextIncompatibleTypeMode loc _ _) =
     err (Just "E-000") (ppPrint e) [(toDiagnosePosition loc, This "Location of the error")] []
 
 instance ToReport ConstraintSolverError where

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -44,9 +44,9 @@ genConstraintsCtxts ((PrdCnsType CnsRep ty1) : rest1) (PrdCnsType CnsRep ty2 : r
   addConstraint $ SubType info ty2 ty1
   genConstraintsCtxts rest1 rest2 info
 genConstraintsCtxts (PrdCnsType PrdRep _:_) (PrdCnsType CnsRep _:_) info =
-  throwGenError (LinearContextIncompatibleTypeMode defaultLoc info)
+  throwGenError (LinearContextIncompatibleTypeMode defaultLoc Prd info)
 genConstraintsCtxts (PrdCnsType CnsRep _:_) (PrdCnsType PrdRep _:_) info =
-  throwGenError (LinearContextIncompatibleTypeMode defaultLoc info)
+  throwGenError (LinearContextIncompatibleTypeMode defaultLoc Cns info)
 genConstraintsCtxts ctx1@[] ctx2@(_:_) info =
   throwGenError (LinearContextsUnequalLength defaultLoc info ctx1 ctx2)
 genConstraintsCtxts ctx1@(_:_) ctx2@[] info =


### PR DESCRIPTION
Turn all the error messages generated during constraint generation to constructors of a sum type `ConstraintGenerationError`.