### PR TITLE
Provide precise error locations from constraint generation

### DIFF
--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -83,7 +83,7 @@ inferPrdCnsDeclaration mn Core.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcd
   let genFun = case pcdecl_isRec of
         Recursive -> genConstraintsTermRecursive mn pcdecl_loc pcdecl_name pcdecl_pc pcdecl_term
         NonRecursive -> genConstraintsTerm pcdecl_term
-  (tmInferred, constraintSet) <- liftEitherErrLoc pcdecl_loc $ runGenM env genFun
+  (tmInferred, constraintSet) <- liftEitherErrLoc pcdecl_loc $ runGenM pcdecl_loc env genFun
   guardVerbose $ ppPrintIO constraintSet
   -- 2. Solve the constraints.
   solverResult <- liftEitherErrLoc pcdecl_loc $ solveConstraints constraintSet env
@@ -134,7 +134,7 @@ inferCommandDeclaration :: ModuleName
 inferCommandDeclaration mn Core.MkCommandDeclaration { cmddecl_loc, cmddecl_doc, cmddecl_name, cmddecl_cmd } = do
   env <- gets drvEnv
   -- Generate the constraints
-  (cmdInferred,constraints) <- liftEitherErrLoc cmddecl_loc $ runGenM env (genConstraintsCommand cmddecl_cmd)
+  (cmdInferred,constraints) <- liftEitherErrLoc cmddecl_loc $ runGenM cmddecl_loc env (genConstraintsCommand cmddecl_cmd)
   -- Solve the constraints
   solverResult <- liftEitherErrLoc cmddecl_loc $ solveConstraints constraints env
   guardVerbose $ do
@@ -155,7 +155,7 @@ inferInstanceDeclaration :: ModuleName
 inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_name, instancedecl_typ } = do
   env <- gets drvEnv
   -- Generate the constraints
-  (instanceInferred,constraints) <- liftEitherErrLoc instancedecl_loc $ runGenM env (genConstraintsInstance decl)
+  (instanceInferred,constraints) <- liftEitherErrLoc instancedecl_loc $ runGenM instancedecl_loc env (genConstraintsInstance decl)
   -- Solve the constraints
   solverResult <- liftEitherErrLoc instancedecl_loc $ solveConstraints constraints env
   guardVerbose $ do

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -83,7 +83,7 @@ inferPrdCnsDeclaration mn Core.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcd
   let genFun = case pcdecl_isRec of
         Recursive -> genConstraintsTermRecursive mn pcdecl_loc pcdecl_name pcdecl_pc pcdecl_term
         NonRecursive -> genConstraintsTerm pcdecl_term
-  (tmInferred, constraintSet) <- liftEitherErrLoc pcdecl_loc $ runGenM pcdecl_loc env genFun
+  (tmInferred, constraintSet) <- liftEitherErr (runGenM pcdecl_loc env genFun)
   guardVerbose $ ppPrintIO constraintSet
   -- 2. Solve the constraints.
   solverResult <- liftEitherErrLoc pcdecl_loc $ solveConstraints constraintSet env
@@ -134,7 +134,7 @@ inferCommandDeclaration :: ModuleName
 inferCommandDeclaration mn Core.MkCommandDeclaration { cmddecl_loc, cmddecl_doc, cmddecl_name, cmddecl_cmd } = do
   env <- gets drvEnv
   -- Generate the constraints
-  (cmdInferred,constraints) <- liftEitherErrLoc cmddecl_loc $ runGenM cmddecl_loc env (genConstraintsCommand cmddecl_cmd)
+  (cmdInferred,constraints) <- liftEitherErr (runGenM cmddecl_loc env (genConstraintsCommand cmddecl_cmd))
   -- Solve the constraints
   solverResult <- liftEitherErrLoc cmddecl_loc $ solveConstraints constraints env
   guardVerbose $ do
@@ -155,7 +155,7 @@ inferInstanceDeclaration :: ModuleName
 inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_name, instancedecl_typ } = do
   env <- gets drvEnv
   -- Generate the constraints
-  (instanceInferred,constraints) <- liftEitherErrLoc instancedecl_loc $ runGenM instancedecl_loc env (genConstraintsInstance decl)
+  (instanceInferred,constraints) <- liftEitherErr (runGenM instancedecl_loc env (genConstraintsInstance decl))
   -- Solve the constraints
   solverResult <- liftEitherErrLoc instancedecl_loc $ solveConstraints constraints env
   guardVerbose $ do

--- a/src/Pretty/Errors.hs
+++ b/src/Pretty/Errors.hs
@@ -23,6 +23,7 @@ import Syntax.Common.Primitives ( primTypeKeyword, primOpKeyword )
 import Utils (Loc (Loc), HasLoc (getLoc))
 import Text.Megaparsec (SourcePos(..), unPos)
 import Syntax.Common (PrdCns(..))
+import System.Directory (doesFileExist)
 
 ---------------------------------------------------------------------------------
 -- Prettyprinting of Errors
@@ -254,9 +255,10 @@ printLocatedReport r = liftIO $ do
   let report = toReport r
   let diag = addReport def report
   let (Loc (SourcePos fp _ _) _) = getLoc r
-  case fp of
-    "<interactive>" -> printDiagnostic stdout True True 4 defaultStyle diag
-    fp -> do
+  fileExists <- doesFileExist fp
+  if not fileExists
+    then printDiagnostic stdout True True 4 defaultStyle diag
+    else do
       fileContent <- readFile fp
       let diag' = addFile diag fp fileContent
       printDiagnostic stdout True True 4 defaultStyle diag'

--- a/src/TypeTranslation.hs
+++ b/src/TypeTranslation.hs
@@ -98,7 +98,7 @@ translateTypeUpper' (TyNominal _ NegRep _ tn _) = do
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
     return $ TyRecVar defaultLoc NegRep Nothing tv
   else do
-    NominalDecl{..} <- lookupTypeName tn
+    NominalDecl{..} <- lookupTypeName defaultLoc tn
     tv <- freshTVar
     case data_polarity of
       Data -> do
@@ -139,7 +139,7 @@ translateTypeLower' (TyNominal _ pr _ tn _) = do
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
     return $ TyRecVar defaultLoc pr Nothing tv
   else do
-    NominalDecl{..} <- lookupTypeName tn
+    NominalDecl{..} <- lookupTypeName defaultLoc tn
     tv <- freshTVar
     case data_polarity of
       Data -> do

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -20,7 +20,7 @@ instance Show Loc where
   show (Loc _s1 _s2) = "<loc>"
 
 defaultLoc :: Loc
-defaultLoc = Loc (SourcePos "" (mkPos 1) (mkPos 1)) (SourcePos "" (mkPos 1) (mkPos 1))
+defaultLoc = Loc (SourcePos "DEFAULTFILELOC" (mkPos 1) (mkPos 1)) (SourcePos "DEFAULTFILELOC" (mkPos 1) (mkPos 1))
 
 -- | A typeclass for things which can be mapped to a source code location.
 class HasLoc a where


### PR DESCRIPTION
Previously, all errors generated during constraint generation were assigned the location of the entire toplevel declaration. With this PR, the precise error location is provided.