### PR TITLE
Move typedecls to syntax

### DIFF
--- a/app/LSP/Handler/CodeAction.hs
+++ b/app/LSP/Handler/CodeAction.hs
@@ -12,7 +12,7 @@ import Control.Monad.IO.Class ( MonadIO(liftIO) )
 
 import LSP.Definition ( LSPMonad )
 import LSP.MegaparsecToLSP ( locToRange, lookupPos, locToEndRange )
-import Syntax.Common.TypesPol ( TypeScheme, TopAnnot(..), DataDecl(..) )
+import Syntax.Common.TypesPol ( TypeScheme, TopAnnot(..))
 import Syntax.Common.Kinds ( EvaluationOrder(..) )
 import Syntax.Common.Names
     ( DocComment,
@@ -22,7 +22,7 @@ import Syntax.Common.PrdCns ( PrdCnsRep(..), PrdCnsToPol )
 import Syntax.Common.Types ( IsRec(Recursive) )
 import Syntax.TST.Terms qualified as TST
 import Syntax.TST.Program qualified as TST
---import Syntax.Core.Program qualified as Core
+import Syntax.RST.Program qualified as RST
 import Driver.Definition
 import Driver.Driver ( inferProgramIO )
 import Utils
@@ -97,7 +97,7 @@ generateCodeAction ident (Range {_start = start}) (TST.CmdDecl decl) | lookupPos
 
 generateCodeAction ident (Range {_start = _start}) (TST.DataDecl decl) = dualizeDecl
   where     
-    dualizeDecl = [generateDualizeDeclCodeAction ident (data_loc decl) decl]
+    dualizeDecl = [generateDualizeDeclCodeAction ident (RST.data_loc decl) decl]
 generateCodeAction _ _ _ = []
 
 ---------------------------------------------------------------------------------
@@ -160,8 +160,8 @@ generateDualizeEdit uri loc doc rep isrec fv tys tm  =
                   , _changeAnnotations = Nothing }
 
 
-generateDualizeDeclCodeAction :: TextDocumentIdentifier -> Loc -> DataDecl -> Command |? CodeAction
-generateDualizeDeclCodeAction (TextDocumentIdentifier uri) loc decl = InR $ CodeAction { _title = "Dualize declaration " <> ppPrint (data_name decl)
+generateDualizeDeclCodeAction :: TextDocumentIdentifier -> Loc -> RST.DataDecl -> Command |? CodeAction
+generateDualizeDeclCodeAction (TextDocumentIdentifier uri) loc decl = InR $ CodeAction { _title = "Dualize declaration " <> ppPrint (RST.data_name decl)
                                                                              , _kind = Just CodeActionQuickFix
                                                                              , _diagnostics = Nothing
                                                                              , _isPreferred = Nothing
@@ -172,7 +172,7 @@ generateDualizeDeclCodeAction (TextDocumentIdentifier uri) loc decl = InR $ Code
                                                                              }
 
 
-generateDualizeDeclEdit :: Uri -> Loc -> DataDecl -> WorkspaceEdit
+generateDualizeDeclEdit :: Uri -> Loc -> RST.DataDecl -> WorkspaceEdit
 generateDualizeDeclEdit uri loc decl =
   let
     decl' = dualDataDecl decl

--- a/app/Repl/Options/Show.hs
+++ b/app/Repl/Options/Show.hs
@@ -19,9 +19,8 @@ import Repl.Repl
 import Driver.Definition (DriverState(..))
 import Driver.Environment
     ( Environment(prdEnv, cnsEnv, cmdEnv, declEnv))
-import Syntax.Common.TypesPol ( DataDecl(data_name) )
-
 import Syntax.Common
+import Syntax.RST.Program qualified as RST
 import Utils (trim)
 
 
@@ -57,7 +56,7 @@ showTypeCmd :: Text -> Repl ()
 showTypeCmd s = do
   env <- gets (drvEnv . replDriverState)
   let concatEnv = concat (fmap snd . declEnv <$> M.elems env)
-  let maybeDecl = find (\x -> rnTnName (data_name x) == MkTypeName s) concatEnv
+  let maybeDecl = find (\x -> rnTnName (RST.data_name x) == MkTypeName s) concatEnv
   case maybeDecl of
     Nothing -> prettyRepl ("Type: " <> s <> " not found in environment.")
     Just decl -> prettyRepl decl

--- a/app/Repl/Run.hs
+++ b/app/Repl/Run.hs
@@ -36,8 +36,8 @@ import Repl.Repl
 import Driver.Definition
 import Driver.Environment
     ( Environment(prdEnv, cnsEnv, cmdEnv, declEnv) )
-import Syntax.Common.TypesPol ( DataDecl(data_name))
 import Syntax.Common
+import Syntax.RST.Program qualified as RST
 
 ------------------------------------------------------------------------------
 -- Options
@@ -130,7 +130,7 @@ cmdCompleter = mkWordCompleter (_simpleComplete f)
       let keys = concat [ unFreeVarName <$> M.keys concatPrdEnv
                         , unFreeVarName <$> M.keys concatCnsEnv
                         , unFreeVarName <$> M.keys concatCmdEnv
-                        , (unTypeName . rnTnName . data_name . snd) <$> concatDeclEnv
+                        , (unTypeName . rnTnName . RST.data_name . snd) <$> concatDeclEnv
                         ]
       return $ filter (isPrefixOf n) (completionList ++ (T.unpack <$> keys))
     _simpleComplete f word = f word >>= return . map simpleCompletion

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -197,7 +197,7 @@ inferDecl mn (Core.CmdDecl decl) = do
 --
 inferDecl mn (Core.DataDecl decl) = do
   -- Insert into environment
-  let f env = env { declEnv = (data_loc decl,decl) : declEnv env }
+  let f env = env { declEnv = (RST.data_loc decl,decl) : declEnv env }
   modifyEnvironment mn f
   pure (TST.DataDecl decl)
 --

--- a/src/Driver/Environment.hs
+++ b/src/Driver/Environment.hs
@@ -6,8 +6,8 @@ import Data.Set (Set)
 
 import Syntax.Common
 import Syntax.TST.Terms ( Command, Term )
-import Syntax.RST.Program ( ClassDeclaration )
-import Syntax.Common.TypesPol ( DataDecl, TypeScheme, Typ )
+import Syntax.RST.Program ( ClassDeclaration, DataDecl )
+import Syntax.Common.TypesPol ( TypeScheme, Typ )
 import Utils ( Loc )
 
 ---------------------------------------------------------------------------------

--- a/src/Dualize/Program.hs
+++ b/src/Dualize/Program.hs
@@ -2,6 +2,7 @@ module Dualize.Program where
 
 import Syntax.Common
 import Syntax.Common.TypesPol
+import Syntax.RST.Program qualified as RST
 import Dualize.Terms
 
 flipDC :: DataCodata -> DataCodata
@@ -11,9 +12,9 @@ flipDC Codata = Data
 dualPolyKind :: PolyKind -> PolyKind 
 dualPolyKind pk = pk 
 
-dualDataDecl :: DataDecl -> DataDecl
-dualDataDecl (NominalDecl loc doc isRefined rntn dc pk (sigsPos,sigsNeg)  ) =
-    NominalDecl loc doc isRefined (dualRnTypeName rntn)  (flipDC dc) (dualPolyKind pk) (dualXtorSig PosRep <$> sigsPos,dualXtorSig NegRep <$> sigsNeg ) 
+dualDataDecl :: RST.DataDecl -> RST.DataDecl
+dualDataDecl (RST.NominalDecl loc doc isRefined rntn dc pk (sigsPos,sigsNeg)  ) =
+    RST.NominalDecl loc doc isRefined (dualRnTypeName rntn)  (flipDC dc) (dualPolyKind pk) (dualXtorSig PosRep <$> sigsPos,dualXtorSig NegRep <$> sigsNeg ) 
 
 dualXtorSig ::  PolarityRep pol -> XtorSig pol -> XtorSig pol 
 dualXtorSig pol (MkXtorSig xtor lctx) = MkXtorSig (dualXtorName xtor) (dualPrdCnsType pol <$> lctx)

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -90,23 +90,23 @@ lookupCommand loc fv = do
 
 -- | Find the type declaration belonging to a given Xtor Name.
 lookupDataDecl :: EnvReader a m
-               => Loc -> XtorName -> m DataDecl
+               => Loc -> XtorName -> m RST.DataDecl
 lookupDataDecl loc xt = do
   let containsXtor :: XtorSig Pos -> Bool
       containsXtor sig = sig_name sig == xt
-  let typeContainsXtor :: DataDecl -> Bool
-      typeContainsXtor NominalDecl { data_xtors } | or (containsXtor <$> fst data_xtors) = True
-                                                  | otherwise = False
+  let typeContainsXtor :: RST.DataDecl -> Bool
+      typeContainsXtor RST.NominalDecl { data_xtors } | or (containsXtor <$> fst data_xtors) = True
+                                                      | otherwise = False
   let err = ErrOther $ SomeOtherError loc ("Constructor/Destructor " <> ppPrint xt <> " is not contained in program.")
   let f env = find typeContainsXtor (fmap snd (declEnv env))
   snd <$> findFirstM f err
 
 -- | Find the type declaration belonging to a given TypeName.
 lookupTypeName :: EnvReader a m
-               => Loc -> RnTypeName -> m DataDecl
+               => Loc -> RnTypeName -> m RST.DataDecl
 lookupTypeName loc tn = do
   let err = ErrOther $ SomeOtherError loc ("Type name " <> unTypeName (rnTnName tn) <> " not found in environment")
-  let f env = find (\NominalDecl{..} -> data_name == tn) (fmap snd (declEnv env))
+  let f env = find (\RST.NominalDecl{..} -> data_name == tn) (fmap snd (declEnv env))
   snd <$> findFirstM f err
 
 -- | Find the XtorSig belonging to a given XtorName.
@@ -114,14 +114,14 @@ lookupXtorSig :: EnvReader a m
               => Loc -> XtorName -> PolarityRep pol -> m (XtorSig pol)
 lookupXtorSig loc xtn PosRep = do
   decl <- lookupDataDecl loc xtn
-  case find ( \MkXtorSig{..} -> sig_name == xtn ) (fst (data_xtors decl)) of
+  case find ( \MkXtorSig{..} -> sig_name == xtn ) (fst (RST.data_xtors decl)) of
     Just xts -> return xts
-    Nothing -> throwOtherError loc ["XtorName " <> unXtorName xtn <> " not found in declaration of type " <> unTypeName (rnTnName (data_name decl))]
+    Nothing -> throwOtherError loc ["XtorName " <> unXtorName xtn <> " not found in declaration of type " <> unTypeName (rnTnName (RST.data_name decl))]
 lookupXtorSig loc xtn NegRep = do
   decl <- lookupDataDecl loc xtn
-  case find ( \MkXtorSig{..} -> sig_name == xtn ) (snd (data_xtors decl)) of
+  case find ( \MkXtorSig{..} -> sig_name == xtn ) (snd (RST.data_xtors decl)) of
     Just xts -> return xts
-    Nothing -> throwOtherError loc ["XtorName " <> unXtorName xtn <> " not found in declaration of type " <> unTypeName (rnTnName (data_name decl))]
+    Nothing -> throwOtherError loc ["XtorName " <> unXtorName xtn <> " not found in declaration of type " <> unTypeName (rnTnName (RST.data_name decl))]
 
 -- | Find the class declaration for a classname.
 lookupClassDecl :: EnvReader a m

--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -12,7 +12,6 @@ import Pretty.Common
 import Syntax.Common
 import Syntax.CST.Program qualified as CST
 import Syntax.Common.TypesUnpol qualified as Unpol
-import Syntax.Common.TypesPol qualified as Pol
 import Syntax.Core.Program qualified as Core
 import Syntax.RST.Program qualified as RST
 import Syntax.TST.Program qualified as TST
@@ -39,7 +38,7 @@ instance PrettyAnn CST.DataDecl where
     braces (mempty <+> cat (punctuate " , " (prettyAnn <$> xtors)) <+> mempty) <>
     semi
 
-instance PrettyAnn Pol.DataDecl where
+instance PrettyAnn RST.DataDecl where
   prettyAnn decl = prettyAnn (embedTyDecl decl)
 
 ---------------------------------------------------------------------------------

--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -24,8 +24,8 @@ import Syntax.CST.Program (PrdCnsDeclaration(pcdecl_term))
 -- Data declarations
 ---------------------------------------------------------------------------------
 
-instance PrettyAnn Unpol.DataDecl where
-  prettyAnn (Unpol.NominalDecl _ _ ref tn dc knd xtors) =
+instance PrettyAnn CST.DataDecl where
+  prettyAnn (CST.NominalDecl _ _ ref tn dc knd xtors) =
     (case ref of
       Refined -> annKeyword "refinement" <+> mempty
       NotRefined -> mempty) <>

--- a/src/Syntax/CST/Program.hs
+++ b/src/Syntax/CST/Program.hs
@@ -215,6 +215,33 @@ deriving instance Show ClassDeclaration
 instance HasLoc ClassDeclaration where
   getLoc decl = classdecl_loc decl
 
+------------------------------------------------------------------------------
+-- Data Type declarations
+------------------------------------------------------------------------------
+
+-- | A toplevel declaration of a data or codata type.
+data DataDecl = NominalDecl
+  { data_loc :: Loc
+    -- ^ The source code location of the declaration.
+  , data_doc :: Maybe DocComment
+    -- ^ The documentation string of the declaration.
+  , data_refined :: IsRefined
+    -- ^ Whether an ordinary or a refinement type is declared.
+  , data_name :: TypeName
+    -- ^ The name of the type. E.g. "List".
+  , data_polarity :: DataCodata
+    -- ^ Whether a data or codata type is declared.
+  , data_kind :: Maybe PolyKind
+    -- ^ The kind of the type constructor.
+  , data_xtors :: [XtorSig]
+    -- The constructors/destructors of the declaration.
+  }
+
+deriving instance Show DataDecl
+
+instance HasLoc DataDecl where
+  getLoc decl = data_loc decl
+
 ---------------------------------------------------------------------------------
 -- Declarations
 ---------------------------------------------------------------------------------

--- a/src/Syntax/Common/TypesPol.hs
+++ b/src/Syntax/Common/TypesPol.hs
@@ -304,27 +304,3 @@ unfoldRecType :: Typ pol -> Typ pol
 unfoldRecType recty@(TyRec _ PosRep var ty) = zonk RecRep (MkBisubstitution (M.fromList [(var,(recty, error "unfoldRecType"))])) ty
 unfoldRecType recty@(TyRec _ NegRep var ty) = zonk RecRep (MkBisubstitution (M.fromList [(var,(error "unfoldRecType", recty))])) ty
 unfoldRecType ty = ty
-
-------------------------------------------------------------------------------
--- Data Type declarations
-------------------------------------------------------------------------------
-
--- | A toplevel declaration of a data or codata type.
-data DataDecl = NominalDecl
-  { data_loc :: Loc
-    -- ^ The source code location of the declaration.
-  , data_doc :: Maybe DocComment
-    -- ^ The documentation string of the declaration.
-  , data_refined :: IsRefined
-    -- ^ Whether an ordinary or a refinement type is declared.
-  , data_name :: RnTypeName
-    -- ^ The name of the type. E.g. "List".
-  , data_polarity :: DataCodata
-    -- ^ Whether a data or codata type is declared.
-  , data_kind :: PolyKind
-    -- ^ The kind of the type constructor.
-  , data_xtors :: ([XtorSig Pos], [XtorSig Neg])
-    -- The constructors/destructors of the declaration.
-  }
-
-deriving instance (Show DataDecl)

--- a/src/Syntax/Common/TypesUnpol.hs
+++ b/src/Syntax/Common/TypesUnpol.hs
@@ -75,33 +75,6 @@ data TypeScheme = TypeScheme
 instance HasLoc TypeScheme where
   getLoc ts = ts_loc ts
 
-------------------------------------------------------------------------------
--- Data Type declarations
-------------------------------------------------------------------------------
-
--- | A toplevel declaration of a data or codata type.
-data DataDecl = NominalDecl
-  { data_loc :: Loc
-    -- ^ The source code location of the declaration.
-  , data_doc :: Maybe DocComment
-    -- ^ The documentation string of the declaration.
-  , data_refined :: IsRefined
-    -- ^ Whether an ordinary or a refinement type is declared.
-  , data_name :: TypeName
-    -- ^ The name of the type. E.g. "List".
-  , data_polarity :: DataCodata
-    -- ^ Whether a data or codata type is declared.
-  , data_kind :: Maybe PolyKind
-    -- ^ The kind of the type constructor.
-  , data_xtors :: [XtorSig]
-    -- The constructors/destructors of the declaration.
-  }
-
-deriving instance (Show DataDecl)
-
-instance HasLoc DataDecl where
-  getLoc decl = data_loc decl
-
 ---------------------------------------------------------------------------------
 -- Constraints
 ---------------------------------------------------------------------------------

--- a/src/Syntax/Core/Program.hs
+++ b/src/Syntax/Core/Program.hs
@@ -2,7 +2,7 @@ module Syntax.Core.Program where
 
 import Syntax.Common
 import Syntax.Core.Terms( Command, Term, InstanceCase )
-import Syntax.Common.TypesPol ( DataDecl, TypeScheme, Typ )
+import Syntax.Common.TypesPol ( TypeScheme, Typ )
 import Syntax.RST.Program qualified as RST
 import Syntax.CST.Program qualified as CST
 import Utils ( Loc )
@@ -77,7 +77,7 @@ deriving instance Show InstanceDeclaration
 data Declaration where
   PrdCnsDecl     :: PrdCnsRep pc -> PrdCnsDeclaration pc -> Declaration
   CmdDecl        :: CommandDeclaration                   -> Declaration
-  DataDecl       :: DataDecl                             -> Declaration
+  DataDecl       :: RST.DataDecl                         -> Declaration
   XtorDecl       :: RST.StructuralXtorDeclaration        -> Declaration
   ImportDecl     :: CST.ImportDeclaration                -> Declaration
   SetDecl        :: CST.SetDeclaration                   -> Declaration

--- a/src/Syntax/RST/Program.hs
+++ b/src/Syntax/RST/Program.hs
@@ -3,7 +3,7 @@ module Syntax.RST.Program where
 
 import Syntax.Common
 import Syntax.RST.Terms( Command, Term, InstanceCase )
-import Syntax.Common.TypesPol ( TypeScheme, DataDecl, Typ, MethodSig )
+import Syntax.Common.TypesPol ( TypeScheme, Typ, MethodSig, XtorSig)
 import Utils ( Loc )
 import Syntax.CST.Program qualified as CST
 
@@ -154,6 +154,30 @@ data ClassDeclaration = MkClassDeclaration
   }
 
 deriving instance Show ClassDeclaration
+
+------------------------------------------------------------------------------
+-- Data Type declarations
+------------------------------------------------------------------------------
+
+-- | A toplevel declaration of a data or codata type.
+data DataDecl = NominalDecl
+  { data_loc :: Loc
+    -- ^ The source code location of the declaration.
+  , data_doc :: Maybe DocComment
+    -- ^ The documentation string of the declaration.
+  , data_refined :: IsRefined
+    -- ^ Whether an ordinary or a refinement type is declared.
+  , data_name :: RnTypeName
+    -- ^ The name of the type. E.g. "List".
+  , data_polarity :: DataCodata
+    -- ^ Whether a data or codata type is declared.
+  , data_kind :: PolyKind
+    -- ^ The kind of the type constructor.
+  , data_xtors :: ([XtorSig Pos], [XtorSig Neg])
+    -- The constructors/destructors of the declaration.
+  }
+
+deriving instance Show DataDecl
 
 ---------------------------------------------------------------------------------
 -- Declarations

--- a/src/Syntax/TST/Program.hs
+++ b/src/Syntax/TST/Program.hs
@@ -5,7 +5,7 @@ import Syntax.Common
 import Syntax.TST.Terms( Command, Term, InstanceCase )
 import Syntax.RST.Program qualified as RST
 import Syntax.CST.Program qualified as CST
-import Syntax.Common.TypesPol ( DataDecl, TopAnnot, Typ )
+import Syntax.Common.TypesPol ( TopAnnot, Typ )
 import Utils ( Loc )
 
 
@@ -78,7 +78,7 @@ deriving instance Show InstanceDeclaration
 data Declaration where
   PrdCnsDecl     :: PrdCnsRep pc -> PrdCnsDeclaration pc -> Declaration
   CmdDecl        :: CommandDeclaration                   -> Declaration
-  DataDecl       :: DataDecl                             -> Declaration
+  DataDecl       :: RST.DataDecl                         -> Declaration
   XtorDecl       :: RST.StructuralXtorDeclaration        -> Declaration
   ImportDecl     :: CST.ImportDeclaration                -> Declaration
   SetDecl        :: CST.SetDeclaration                   -> Declaration

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -8,6 +8,7 @@ module TypeInference.GenerateConstraints.Terms
 import Control.Monad.Reader
 import Data.Map qualified as M
 import Errors
+import Syntax.RST.Program qualified as RST
 import Syntax.TST.Terms qualified as TST
 import Syntax.TST.Program qualified as TST
 import Syntax.Core.Terms qualified as Core
@@ -112,8 +113,8 @@ genConstraintsTerm (Core.Xtor loc annot rep Nominal xt subst) = do
   -- and the types we looked up, i.e. the types declared in the XtorSig.
   genConstraintsCtxts substTypes sig_args' (case rep of { PrdRep -> CtorArgsConstraint loc; CnsRep -> DtorArgsConstraint loc })
   case rep of
-    PrdRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc PosRep Nothing (data_name decl) args) Nominal xt substInferred)
-    CnsRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc NegRep Nothing (data_name decl) args) Nominal xt substInferred)
+    PrdRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc PosRep Nothing (RST.data_name decl) args) Nominal xt substInferred)
+    CnsRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc NegRep Nothing (RST.data_name decl) args) Nominal xt substInferred)
 --
 -- Refinement Xtors
 --
@@ -129,8 +130,8 @@ genConstraintsTerm (Core.Xtor loc annot rep Refinement xt subst) = do
   -- and the translations of the types we looked up, i.e. the types declared in the XtorSig.
   genConstraintsCtxts substTypes (sig_args xtorSigUpper) (case rep of { PrdRep -> CtorArgsConstraint loc; CnsRep -> DtorArgsConstraint loc })
   case rep of
-    PrdRep -> return (TST.Xtor loc annot rep (TyDataRefined   defaultLoc PosRep (data_name decl) [MkXtorSig xt substTypes]) Refinement xt substInferred)
-    CnsRep -> return (TST.Xtor loc annot rep (TyCodataRefined defaultLoc NegRep (data_name decl) [MkXtorSig xt substTypes]) Refinement xt substInferred)
+    PrdRep -> return (TST.Xtor loc annot rep (TyDataRefined   defaultLoc PosRep (RST.data_name decl) [MkXtorSig xt substTypes]) Refinement xt substInferred)
+    CnsRep -> return (TST.Xtor loc annot rep (TyCodataRefined defaultLoc NegRep (RST.data_name decl) [MkXtorSig xt substTypes]) Refinement xt substInferred)
 --
 -- Structural pattern and copattern matches:
 --
@@ -176,8 +177,8 @@ genConstraintsTerm (Core.XCase loc annot rep Nominal cases@(pmcase:_)) = do
                    cmdInferred <- withContext posTypes' (genConstraintsCommand cmdcase_cmd)
                    return (TST.MkCmdCase cmdcase_loc (TST.XtorPat loc' xt args) cmdInferred, MkXtorSig xt negTypes'))
   case rep of
-    PrdRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc PosRep Nothing (data_name decl) args) Nominal (fst <$> inferredCases)
-    CnsRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc NegRep Nothing (data_name decl) args) Nominal (fst <$> inferredCases)
+    PrdRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc PosRep Nothing (RST.data_name decl) args) Nominal (fst <$> inferredCases)
+    CnsRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc NegRep Nothing (RST.data_name decl) args) Nominal (fst <$> inferredCases)
 --
 -- Refinement pattern and copattern matches
 --
@@ -207,8 +208,8 @@ genConstraintsTerm (Core.XCase loc annot rep Refinement cases@(pmcase:_)) = do
                        -- and greatest type translation.
                        return (TST.MkCmdCase cmdcase_loc (TST.XtorPat loc xt args) cmdInferred, MkXtorSig xt uvarsNeg))
   case rep of
-    PrdRep -> return $ TST.XCase loc annot rep (TyCodataRefined defaultLoc PosRep (data_name decl) (snd <$> inferredCases)) Refinement (fst <$> inferredCases)
-    CnsRep -> return $ TST.XCase loc annot rep (TyDataRefined   defaultLoc NegRep (data_name decl) (snd <$> inferredCases)) Refinement (fst <$> inferredCases)
+    PrdRep -> return $ TST.XCase loc annot rep (TyCodataRefined defaultLoc PosRep (RST.data_name decl) (snd <$> inferredCases)) Refinement (fst <$> inferredCases)
+    CnsRep -> return $ TST.XCase loc annot rep (TyDataRefined   defaultLoc NegRep (RST.data_name decl) (snd <$> inferredCases)) Refinement (fst <$> inferredCases)
 --
 -- Mu and TildeMu abstractions:
 --

--- a/src/TypeTranslation.hs
+++ b/src/TypeTranslation.hs
@@ -23,6 +23,7 @@ import Pretty.Types ()
 import Driver.Environment
 import Syntax.Common.TypesPol
 import Syntax.Common
+import Syntax.RST.Program qualified as RST
 import Utils
 
 ---------------------------------------------------------------------------------------------
@@ -98,7 +99,7 @@ translateTypeUpper' (TyNominal _ NegRep _ tn _) = do
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
     return $ TyRecVar defaultLoc NegRep Nothing tv
   else do
-    NominalDecl{..} <- lookupTypeName defaultLoc tn
+    RST.NominalDecl{..} <- lookupTypeName defaultLoc tn
     tv <- freshTVar
     case data_polarity of
       Data -> do
@@ -139,7 +140,7 @@ translateTypeLower' (TyNominal _ pr _ tn _) = do
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
     return $ TyRecVar defaultLoc pr Nothing tv
   else do
-    NominalDecl{..} <- lookupTypeName defaultLoc tn
+    RST.NominalDecl{..} <- lookupTypeName defaultLoc tn
     tv <- freshTVar
     case data_polarity of
       Data -> do


### PR DESCRIPTION
Move the toplevel data/codata declarations into the `Syntax/XXX/Program` modules from the `TypesPol` resp. `TypesUnpol` modules.