### PR TITLE
Split Data Decl

### DIFF
--- a/duo-lang.cabal
+++ b/duo-lang.cabal
@@ -80,6 +80,7 @@ common shared-lang-options
 common shared-ghc-opts
   ghc-options:
     -Wall
+    -Wincomplete-uni-patterns
     -fwarn-tabs
     -fno-warn-name-shadowing
     -fno-warn-orphans

--- a/src/Dualize/Program.hs
+++ b/src/Dualize/Program.hs
@@ -13,8 +13,10 @@ dualPolyKind :: PolyKind -> PolyKind
 dualPolyKind pk = pk 
 
 dualDataDecl :: RST.DataDecl -> RST.DataDecl
-dualDataDecl (RST.NominalDecl loc doc isRefined rntn dc pk (sigsPos,sigsNeg)  ) =
-    RST.NominalDecl loc doc isRefined (dualRnTypeName rntn)  (flipDC dc) (dualPolyKind pk) (dualXtorSig PosRep <$> sigsPos,dualXtorSig NegRep <$> sigsNeg ) 
+dualDataDecl (RST.NominalDecl loc doc rntn dc pk (sigsPos,sigsNeg)) =
+    RST.NominalDecl loc doc (dualRnTypeName rntn)  (flipDC dc) (dualPolyKind pk) (dualXtorSig PosRep <$> sigsPos,dualXtorSig NegRep <$> sigsNeg )
+dualDataDecl (RST.RefinementDecl loc doc rntn dc pk (sigsPos,sigsNeg)) =
+    RST.RefinementDecl loc doc (dualRnTypeName rntn)  (flipDC dc) (dualPolyKind pk) (dualXtorSig PosRep <$> sigsPos,dualXtorSig NegRep <$> sigsNeg )
 
 dualXtorSig ::  PolarityRep pol -> XtorSig pol -> XtorSig pol 
 dualXtorSig pol (MkXtorSig xtor lctx) = MkXtorSig (dualXtorName xtor) (dualPrdCnsType pol <$> lctx)

--- a/src/Lookup.hs
+++ b/src/Lookup.hs
@@ -97,6 +97,8 @@ lookupDataDecl loc xt = do
   let typeContainsXtor :: RST.DataDecl -> Bool
       typeContainsXtor RST.NominalDecl { data_xtors } | or (containsXtor <$> fst data_xtors) = True
                                                       | otherwise = False
+      typeContainsXtor RST.RefinementDecl { data_xtors } | or (containsXtor <$> fst data_xtors) = True
+                                                         | otherwise = False                                                      
   let err = ErrOther $ SomeOtherError loc ("Constructor/Destructor " <> ppPrint xt <> " is not contained in program.")
   let f env = find typeContainsXtor (fmap snd (declEnv env))
   snd <$> findFirstM f err
@@ -106,7 +108,9 @@ lookupTypeName :: EnvReader a m
                => Loc -> RnTypeName -> m RST.DataDecl
 lookupTypeName loc tn = do
   let err = ErrOther $ SomeOtherError loc ("Type name " <> unTypeName (rnTnName tn) <> " not found in environment")
-  let f env = find (\RST.NominalDecl{..} -> data_name == tn) (fmap snd (declEnv env))
+  let findFun RST.NominalDecl{..} = data_name == tn
+      findFun RST.RefinementDecl {..} = data_name == tn
+  let f env = find findFun (fmap snd (declEnv env))
   snd <$> findFirstM f err
 
 -- | Find the XtorSig belonging to a given XtorName.

--- a/src/Resolution/Pattern.hs
+++ b/src/Resolution/Pattern.hs
@@ -106,12 +106,14 @@ analyzePattern dc pat = do
           vars <- sequence (fromVar <$> pats)
           pure $ ExplicitPattern loc xt vars
         1 -> do
-          let (args1,PatStar _ pc:args2) = break isStar pats
-          args1' <- sequence (fromVar <$> args1)
-          args2' <- sequence (fromVar <$> args2)
-          case pc of
-            Cns -> pure $ ImplicitPrdPattern loc xt (args1', PrdRep, args2')
-            Prd -> pure $ ImplicitCnsPattern loc xt (args1', CnsRep, args2')
+          case break isStar pats of
+            (args1,PatStar _ pc:args2) -> do
+              args1' <- sequence (fromVar <$> args1)
+              args2' <- sequence (fromVar <$> args2)
+              case pc of
+                Cns -> pure $ ImplicitPrdPattern loc xt (args1', PrdRep, args2')
+                Prd -> pure $ ImplicitCnsPattern loc xt (args1', CnsRep, args2')
+            (_,_) -> throwOtherError loc ["Not reachable, since number \"1\" was returned in the check."]
         n -> throwError $ ErrResolution (InvalidStar loc ("More than one star used in binding site: " <> T.pack (show n) <> " stars used.")) :| []
     _ -> throwOtherError (getLoc pat) ["Invalid pattern in function \"analyzePattern\""]
 

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -116,15 +116,21 @@ resolveDataDecl CST.NominalDecl { data_loc, data_doc, data_refined, data_name, d
       h r = r { rr_modules = f $ rr_modules r }
   xtors <- local h (resolveXtors data_xtors)
   -- Create the new data declaration
-  let dcl = RST.NominalDecl
-                { data_loc = data_loc
-                , data_doc = data_doc
-                , data_refined = data_refined
-                , data_name = data_name'
-                , data_polarity = data_polarity
-                , data_kind = polyKind
-                , data_xtors = xtors
-                }
+  let dcl = case data_refined of
+              NotRefined -> RST.NominalDecl { data_loc = data_loc
+                                            , data_doc = data_doc
+                                            , data_name = data_name'
+                                            , data_polarity = data_polarity
+                                            , data_kind = polyKind
+                                            , data_xtors = xtors
+                                            }
+              Refined -> RST.RefinementDecl { data_loc = data_loc
+                                            , data_doc = data_doc
+                                            , data_name = data_name'
+                                            , data_polarity = data_polarity
+                                            , data_kind = polyKind
+                                            , data_xtors = xtors
+                                            }
   pure dcl
 
 ---------------------------------------------------------------------------------

--- a/src/Syntax/RST/Program.hs
+++ b/src/Syntax/RST/Program.hs
@@ -160,13 +160,26 @@ deriving instance Show ClassDeclaration
 ------------------------------------------------------------------------------
 
 -- | A toplevel declaration of a data or codata type.
-data DataDecl = NominalDecl
+data DataDecl =
+    NominalDecl
   { data_loc :: Loc
     -- ^ The source code location of the declaration.
   , data_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
-  , data_refined :: IsRefined
-    -- ^ Whether an ordinary or a refinement type is declared.
+  , data_name :: RnTypeName
+    -- ^ The name of the type. E.g. "List".
+  , data_polarity :: DataCodata
+    -- ^ Whether a data or codata type is declared.
+  , data_kind :: PolyKind
+    -- ^ The kind of the type constructor.
+  , data_xtors :: ([XtorSig Pos], [XtorSig Neg])
+    -- The constructors/destructors of the declaration.
+  }
+  | RefinementDecl
+  { data_loc :: Loc
+    -- ^ The source code location of the declaration.
+  , data_doc :: Maybe DocComment
+    -- ^ The documentation string of the declaration.
   , data_name :: RnTypeName
     -- ^ The name of the type. E.g. "List".
   , data_polarity :: DataCodata

--- a/src/Translate/Reparse.hs
+++ b/src/Translate/Reparse.hs
@@ -520,10 +520,19 @@ embedTypeScheme RST.TypeScheme { ts_loc, ts_vars, ts_monotype } =
 
 
 embedTyDecl :: RST.DataDecl -> CST.DataDecl
-embedTyDecl RST.NominalDecl { data_loc, data_doc, data_refined, data_name, data_polarity, data_kind, data_xtors } =
+embedTyDecl RST.NominalDecl { data_loc, data_doc, data_name, data_polarity, data_kind, data_xtors } =
   CST.NominalDecl { data_loc = data_loc
                   , data_doc = data_doc
-                  , data_refined = data_refined
+                  , data_refined = NotRefined
+                  , data_name = rnTnName data_name
+                  , data_polarity = data_polarity
+                  , data_kind = Just data_kind
+                  , data_xtors = embedXtorSig <$> fst data_xtors
+                  }
+embedTyDecl RST.RefinementDecl { data_loc, data_doc, data_name, data_polarity, data_kind, data_xtors } =
+  CST.NominalDecl { data_loc = data_loc
+                  , data_doc = data_doc
+                  , data_refined = Refined
                   , data_name = rnTnName data_name
                   , data_polarity = data_polarity
                   , data_kind = Just data_kind

--- a/src/TypeAutomata/Subsume.hs
+++ b/src/TypeAutomata/Subsume.hs
@@ -62,7 +62,7 @@ typeAutEqual (TypeAut _ (Identity start1) (TypeAutCore gr1 flowEdges1))
       Nothing -> False
       Just ((),mp) ->
         S.fromList flowEdges2 ==
-          S.fromList [(i',j') | (i,j) <- flowEdges1, let Just i' = M.lookup i mp, let Just j' = M.lookup j mp]
+          S.fromList [(i',j') | (i,j) <- flowEdges1, let i' = fromJust (M.lookup i mp), let j' = fromJust (M.lookup j mp)]
 
 sucWith :: (DynGraph gr, Eq b) => gr a b -> Node -> b -> Maybe Node
 sucWith gr i el = lookup el (map swap (lsuc gr i))

--- a/src/TypeTranslation.hs
+++ b/src/TypeTranslation.hs
@@ -99,16 +99,28 @@ translateTypeUpper' (TyNominal _ NegRep _ tn _) = do
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
     return $ TyRecVar defaultLoc NegRep Nothing tv
   else do
-    RST.NominalDecl{..} <- lookupTypeName defaultLoc tn
-    tv <- freshTVar
-    case data_polarity of
-      Data -> do
-        -- Recursively translate xtor sig with mapping of current type name to new rec type var
-        xtss <- mapM (withVarMap (M.insert tn tv) . translateXtorSigUpper') $ snd data_xtors
-        return $ TyRec defaultLoc NegRep tv $ TyDataRefined defaultLoc NegRep tn xtss
-      Codata -> do
-        -- Upper bound translation of codata is empty
-        return $ TyRec defaultLoc NegRep tv $ TyCodataRefined defaultLoc NegRep tn []
+    decl <- lookupTypeName defaultLoc tn
+    case decl of
+      RST.NominalDecl{..} -> do
+        tv <- freshTVar
+        case data_polarity of
+          Data -> do
+            -- Recursively translate xtor sig with mapping of current type name to new rec type var
+            xtss <- mapM (withVarMap (M.insert tn tv) . translateXtorSigUpper') $ snd data_xtors
+            return $ TyRec defaultLoc NegRep tv $ TyDataRefined defaultLoc NegRep tn xtss
+          Codata -> do
+            -- Upper bound translation of codata is empty
+            return $ TyRec defaultLoc NegRep tv $ TyCodataRefined defaultLoc NegRep tn []
+      RST.RefinementDecl{..} -> do
+        tv <- freshTVar
+        case data_polarity of
+          Data -> do
+            -- Recursively translate xtor sig with mapping of current type name to new rec type var
+            xtss <- mapM (withVarMap (M.insert tn tv) . translateXtorSigUpper') $ snd data_xtors
+            return $ TyRec defaultLoc NegRep tv $ TyDataRefined defaultLoc NegRep tn xtss
+          Codata -> do
+            -- Upper bound translation of codata is empty
+            return $ TyRec defaultLoc NegRep tv $ TyCodataRefined defaultLoc NegRep tn []
 translateTypeUpper' tv@TySkolemVar{} = return tv
 translateTypeUpper' ty = throwOtherError defaultLoc ["Cannot translate type " <> ppPrint ty]
 
@@ -140,16 +152,28 @@ translateTypeLower' (TyNominal _ pr _ tn _) = do
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
     return $ TyRecVar defaultLoc pr Nothing tv
   else do
-    RST.NominalDecl{..} <- lookupTypeName defaultLoc tn
-    tv <- freshTVar
-    case data_polarity of
-      Data -> do
-        -- Lower bound translation of data is empty
-        return $ TyRec defaultLoc pr tv $ TyDataRefined defaultLoc pr tn []
-      Codata -> do
-        -- Recursively translate xtor sig with mapping of current type name to new rec type var
-        xtss <- mapM (withVarMap (M.insert tn tv) . translateXtorSigUpper') $ snd data_xtors
-        return $ TyRec defaultLoc pr tv $ TyCodataRefined defaultLoc pr tn xtss
+    decl <- lookupTypeName defaultLoc tn
+    case decl of
+      RST.NominalDecl{..} -> do
+        tv <- freshTVar
+        case data_polarity of
+          Data -> do
+            -- Lower bound translation of data is empty
+            return $ TyRec defaultLoc pr tv $ TyDataRefined defaultLoc pr tn []
+          Codata -> do
+            -- Recursively translate xtor sig with mapping of current type name to new rec type var
+            xtss <- mapM (withVarMap (M.insert tn tv) . translateXtorSigUpper') $ snd data_xtors
+            return $ TyRec defaultLoc pr tv $ TyCodataRefined defaultLoc pr tn xtss
+      RST.RefinementDecl{..} -> do
+        tv <- freshTVar
+        case data_polarity of
+          Data -> do
+            -- Lower bound translation of data is empty
+            return $ TyRec defaultLoc pr tv $ TyDataRefined defaultLoc pr tn []
+          Codata -> do
+            -- Recursively translate xtor sig with mapping of current type name to new rec type var
+            xtss <- mapM (withVarMap (M.insert tn tv) . translateXtorSigUpper') $ snd data_xtors
+            return $ TyRec defaultLoc pr tv $ TyCodataRefined defaultLoc pr tn xtss
 translateTypeLower' tv@TySkolemVar{} = return tv
 translateTypeLower' ty = throwOtherError defaultLoc ["Cannot translate type " <> ppPrint ty]
 

--- a/test/Spec/Subsumption.hs
+++ b/test/Spec/Subsumption.hs
@@ -28,8 +28,11 @@ subsumptionCheckPos env bspec s1 s2 = do
           (Left _err, _) -> expectationFailure "Could not lower left example"
           (_, Left _err) -> expectationFailure "Could not lower right example"
           (Right r1, Right r2) -> do
-            let Right b = subsume PosRep r1 r2
-            b `shouldBe` bspec
+            case subsume PosRep r1 r2 of
+              Right b -> b `shouldBe` bspec
+              Left err -> expectationFailure (show err)
+            
+            
 
 
 spec :: [(ModuleName, SymbolTable)] -> Spec


### PR DESCRIPTION
This PR splits the data declarations into two alternatives (NominalDecl and RefinementDecl) during renaming. This is preliminary work in order to find a solution to #359 via #405. I want to replace the `TypeTranslation` module and make it part of the resolution phase, which inserts the correct translations directly into the `RefinementDecl` so that they have to be computed only once during the resolution phase.

I also enabled the warning `Wno-incomplete-uni-patterns` and had to change some code to fix the resulting warnings.