### PR TITLE
Annotate kinds

### DIFF
--- a/src/Dualize/Terms.hs
+++ b/src/Dualize/Terms.hs
@@ -119,10 +119,10 @@ dualType' PrdRep t = dualType PosRep t
 dualType' CnsRep t = dualType NegRep t
 
 dualType :: PolarityRep pol -> Typ pol -> Typ (FlipPol pol)
-dualType pol (TyUniVar _loc _ kind x) = TyUniVar defaultLoc (flipPolarityRep pol) (dualMonoKind <$> kind) x
-dualType pol (TySkolemVar _loc _ kind x) = TySkolemVar defaultLoc (flipPolarityRep pol) (dualMonoKind <$> kind) x
-dualType pol (TyRecVar _loc _ kind x) = TyRecVar defaultLoc (flipPolarityRep pol) (dualMonoKind <$> kind) x
-dualType pol (TyNominal _ _ kind tn vtys) = TyNominal defaultLoc  (flipPolarityRep pol) (dualMonoKind <$> kind) (dualRnTypeName tn) (dualVariantType pol <$> vtys)
+dualType pol (TyUniVar _loc _ kind x) = TyUniVar defaultLoc (flipPolarityRep pol) (dualMonoKind kind) x
+dualType pol (TySkolemVar _loc _ kind x) = TySkolemVar defaultLoc (flipPolarityRep pol) (dualMonoKind kind) x
+dualType pol (TyRecVar _loc _ kind x) = TyRecVar defaultLoc (flipPolarityRep pol) (dualMonoKind kind) x
+dualType pol (TyNominal _ _ kind tn vtys) = TyNominal defaultLoc  (flipPolarityRep pol) (dualMonoKind kind) (dualRnTypeName tn) (dualVariantType pol <$> vtys)
 dualType pol (TyI64 loc _ ) = TyI64 loc (flipPolarityRep pol)
 dualType pol (TyF64 loc _ ) = TyF64 loc (flipPolarityRep pol)
 dualType pol (TyChar loc _ ) = TyChar loc (flipPolarityRep pol)

--- a/src/Eval/Definition.hs
+++ b/src/Eval/Definition.hs
@@ -55,7 +55,7 @@ checkArgs cmd _ _ = throwEvalError defaultLoc [ "Error during evaluation of:"
                                               ]
 
 natType :: Typ 'Pos
-natType = TyNominal defaultLoc PosRep (Just (CBox CBV)) peanoNm []
+natType = TyNominal defaultLoc PosRep (CBox CBV) peanoNm []
 
 convertInt :: Int -> Term Prd
 convertInt 0 = Xtor defaultLoc XtorAnnotOrig PrdRep natType CST.Nominal (MkXtorName "Z") []

--- a/src/Eval/Eval.hs
+++ b/src/Eval/Eval.hs
@@ -38,6 +38,7 @@ evalTermOnce Method {} = return Nothing
   -- throwEvalError defaultLoc ["Eval for type class methods not implemented yet."]
 evalTermOnce (Apply _ _ Nothing _ _) =
   throwEvalError defaultLoc ["Tried to evaluate command which was not correctly kind annotated (Nothing)"]
+evalTermOnce (Apply _ _ (Just (KindVar _)) _ _) = throwEvalError defaultLoc ["Tried to evaluate command which was not correctly kind annotated (KindVar)"]
 evalTermOnce (Apply _ _ (Just kind) prd cns) = evalApplyOnce kind prd cns
 evalTermOnce (PrimOp _ pt op args) = evalPrimOp pt op args
 

--- a/src/Pretty/Common.hs
+++ b/src/Pretty/Common.hs
@@ -23,7 +23,7 @@ import Syntax.Common.Names
 import Syntax.Common.PrdCns ( Arity, PrdCns(..) )
 import Syntax.Common.Primitives ( PrimitiveType(..) )
 import Syntax.CST.Kinds
-    ( EvaluationOrder(..), MonoKind(..), PolyKind(..), Variance(..) )
+    ( EvaluationOrder(..), MonoKind(..), PolyKind(..), Variance(..), KVar(..))
 import Utils ( Loc(..) )
 
 
@@ -129,6 +129,10 @@ instance PrettyAnn MonoKind where
   prettyAnn (CRep F64) = "F64Rep"
   prettyAnn (CRep PChar) = "CharRep"
   prettyAnn (CRep PString) = "StringRep"
+  prettyAnn (KindVar kv) = prettyAnn kv
+
+instance PrettyAnn KVar where
+  prettyAnn (MkKVar kv) = prettyAnn kv
 
 instance PrettyAnn Variance where
   prettyAnn Covariant     = annSymbol "+"

--- a/src/Pretty/TypeAutomata.hs
+++ b/src/Pretty/TypeAutomata.hs
@@ -26,9 +26,10 @@ instance PrettyAnn XtorLabel where
 
 instance PrettyAnn NodeLabel where
   prettyAnn (MkPrimitiveNodeLabel _ tp) = prettyAnn tp
-  prettyAnn (MkNodeLabel _ maybeDat maybeCodat tns refDat refCodat) =
+  prettyAnn (MkNodeLabel _ maybeDat maybeCodat kind tns refDat refCodat) =
     intercalateX ";" (catMaybes [printDat <$> maybeDat
                                 , printCodat <$> maybeCodat
+                                , Just (prettyAnn kind)
                                 , printNominal tns
                                 , printRefDat refDat
                                 , printRefCodat refCodat])

--- a/src/Syntax/CST/Kinds.hs
+++ b/src/Syntax/CST/Kinds.hs
@@ -5,6 +5,7 @@ import Data.Set qualified as S
 
 import Syntax.Common.Names
 import Syntax.Common.Primitives
+import Data.Text
 
 ---------------------------------------------------------------------------------
 -- Variance
@@ -27,6 +28,14 @@ data EvaluationOrder = CBV | CBN
   deriving (Show, Eq, Ord)
 
 ---------------------------------------------------------------------------------
+-- Kind Variables
+---------------------------------------------------------------------------------
+
+-- | A Kind Variable that is used for inferred kinds
+newtype KVar = MkKVar { unKVar :: Text }
+  deriving (Show, Eq, Ord)
+
+---------------------------------------------------------------------------------
 -- MonoKind
 ---------------------------------------------------------------------------------
 
@@ -34,6 +43,7 @@ data EvaluationOrder = CBV | CBN
 data MonoKind
   = CBox EvaluationOrder  -- ^ Boxed CBV/CBN
   | CRep PrimitiveType    -- ^ Primitive type representation
+  | KindVar KVar 
   deriving (Show, Eq, Ord)
 
 ------------------------------------------------------------------------------
@@ -47,6 +57,12 @@ data PolyKind =
 
 deriving instance (Show PolyKind)
 deriving instance (Eq PolyKind)
+deriving instance (Ord PolyKind)
+
+freeKindVars :: MonoKind -> Maybe KVar
+freeKindVars (CBox _) = Nothing
+freeKindVars (CRep _) = Nothing
+freeKindVars (KindVar v) = Just v
 
 allTypeVars :: PolyKind -> Set SkolemTVar
 allTypeVars MkPolyKind{ kindArgs } =

--- a/src/Syntax/RST/Types.hs
+++ b/src/Syntax/RST/Types.hs
@@ -5,6 +5,7 @@ import Data.Set qualified as S
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Kind ( Type )
+import Data.Maybe
 
 import Syntax.Common.PrdCns
     ( Arity, PrdCns(..), PrdCnsFlip, PrdCnsRep(..) )
@@ -86,9 +87,9 @@ deriving instance Show (MethodSig pol)
 
 
 data Typ (pol :: Polarity) where
-  TySkolemVar :: Loc -> PolarityRep pol -> Maybe MonoKind -> SkolemTVar -> Typ pol
-  TyUniVar :: Loc -> PolarityRep pol -> Maybe MonoKind -> UniTVar -> Typ pol
-  TyRecVar :: Loc -> PolarityRep pol -> Maybe MonoKind -> RecTVar -> Typ pol
+  TySkolemVar :: Loc -> PolarityRep pol -> MonoKind -> SkolemTVar -> Typ pol
+  TyUniVar :: Loc -> PolarityRep pol -> MonoKind -> UniTVar -> Typ pol
+  TyRecVar :: Loc -> PolarityRep pol -> MonoKind -> RecTVar -> Typ pol
   -- | We have to duplicate TyStructData and TyStructCodata here due to restrictions of the deriving mechanism of Haskell.
   -- | Refinement types are represented by the presence of the TypeName parameter
   TyData          :: Loc -> PolarityRep pol               -> [XtorSig pol]           -> Typ pol
@@ -96,14 +97,14 @@ data Typ (pol :: Polarity) where
   TyDataRefined   :: Loc -> PolarityRep pol -> RnTypeName -> [XtorSig pol]           -> Typ pol
   TyCodataRefined :: Loc -> PolarityRep pol -> RnTypeName -> [XtorSig (FlipPol pol)] -> Typ pol
   -- | Nominal types with arguments to type parameters (contravariant, covariant)
-  TyNominal :: Loc -> PolarityRep pol -> Maybe MonoKind -> RnTypeName -> [VariantType pol] -> Typ pol
+  TyNominal :: Loc -> PolarityRep pol -> MonoKind -> RnTypeName -> [VariantType pol] -> Typ pol
   -- | Type synonym
   TySyn :: Loc -> PolarityRep pol -> RnTypeName -> Typ pol -> Typ pol
   -- | Lattice types
-  TyBot :: Loc -> Maybe MonoKind -> Typ Pos
-  TyTop :: Loc -> Maybe MonoKind -> Typ Neg
-  TyUnion :: Loc -> Maybe MonoKind -> Typ Pos -> Typ Pos -> Typ Pos
-  TyInter :: Loc -> Maybe MonoKind -> Typ Neg -> Typ Neg -> Typ Neg
+  TyBot :: Loc -> MonoKind -> Typ Pos
+  TyTop :: Loc -> MonoKind -> Typ Neg
+  TyUnion :: Loc -> MonoKind -> Typ Pos -> Typ Pos -> Typ Pos
+  TyInter :: Loc -> MonoKind -> Typ Neg -> Typ Neg -> Typ Neg
   -- | Equirecursive Types
   TyRec :: Loc -> PolarityRep pol -> RecTVar -> Typ pol -> Typ pol
   -- | Builtin Types
@@ -118,12 +119,12 @@ deriving instance Eq (Typ pol)
 deriving instance Ord (Typ pol)
 deriving instance Show (Typ pol)
 
-mkUnion :: Loc -> Maybe MonoKind -> [Typ Pos] -> Typ Pos
+mkUnion :: Loc -> MonoKind -> [Typ Pos] -> Typ Pos
 mkUnion loc knd []     = TyBot loc knd
 mkUnion _   _   [t]    = t
 mkUnion loc knd (t:ts) = TyUnion loc knd t (mkUnion loc knd ts)
 
-mkInter :: Loc -> Maybe MonoKind -> [Typ Neg] -> Typ Neg
+mkInter :: Loc -> MonoKind -> [Typ Neg] -> Typ Neg
 mkInter loc knd []     = TyTop loc knd
 mkInter _   _   [t]    = t
 mkInter loc knd (t:ts) = TyInter loc knd t (mkInter loc knd ts)
@@ -314,13 +315,10 @@ instance Zonk (LinearContext pol) where
 instance Zonk (PrdCnsType pol) where
   zonk vt bisubst (PrdCnsType rep ty) = PrdCnsType rep (zonk vt bisubst ty)
 
-zonkKind :: Bisubstitution UniVT -> Maybe MonoKind -> Maybe MonoKind
-zonkKind _ Nothing = Nothing
-zonkKind _ (Just (CBox cc)) = Just (CBox cc)
-zonkKind _ (Just (CRep prim)) =  Just (CRep prim)
-zonkKind bisubst (Just kindV@(KindVar kv)) = case M.lookup kv (snd (bisubst_map bisubst)) of
-    Nothing -> Just kindV
-    Just kind' -> Just kind'
+zonkKind :: Bisubstitution UniVT -> MonoKind -> MonoKind
+zonkKind _ (CBox cc) = CBox cc
+zonkKind _ (CRep prim) =  CRep prim
+zonkKind bisubst kindV@(KindVar kv) = Data.Maybe.fromMaybe kindV (M.lookup kv (snd (bisubst_map bisubst)))
 
 -- This is probably not 100% correct w.r.t alpha-renaming. Postponed until we have a better repr. of types.
 unfoldRecType :: Typ pol -> Typ pol

--- a/src/TypeAutomata/Definition.hs
+++ b/src/TypeAutomata/Definition.hs
@@ -16,7 +16,7 @@ import Syntax.Common.PrdCns ( Arity, PrdCns )
 import Syntax.CST.Types ( DataCodata(..) )
 import Syntax.Common.Polarity ( Polarity, PolarityRep )
 import Syntax.Common.Primitives ( PrimitiveType )
-import Syntax.CST.Kinds ( Variance )
+import Syntax.CST.Kinds ( Variance, MonoKind(..), EvaluationOrder(..) )
 
 --------------------------------------------------------------------------------
 -- # Type Automata
@@ -156,6 +156,7 @@ data NodeLabel =
     { nl_pol :: Polarity
     , nl_data :: Maybe (Set XtorLabel)
     , nl_codata :: Maybe (Set XtorLabel)
+    , nl_kind :: MonoKind
     -- Nominal type names with the arities of type parameters
     , nl_nominal :: Set (RnTypeName, [Variance])
     , nl_ref_data :: Map RnTypeName (Set XtorLabel)
@@ -168,19 +169,19 @@ data NodeLabel =
     } deriving (Eq,Show,Ord)
 
 emptyNodeLabel :: Polarity -> NodeLabel
-emptyNodeLabel pol = MkNodeLabel pol Nothing Nothing S.empty M.empty M.empty
+emptyNodeLabel pol = MkNodeLabel pol Nothing Nothing (CBox CBV) S.empty M.empty M.empty
 
 -- emptyPrimNodeLabel :: Polarity -> NodeLabel
 -- emptyPrimNodeLabel pol = MkPrimitiveNodeLabel pol S.empty
 
-singleNodeLabel :: Polarity -> DataCodata -> Maybe RnTypeName -> Set XtorLabel -> NodeLabel
-singleNodeLabel pol Data Nothing xtors   = MkNodeLabel pol (Just xtors) Nothing S.empty M.empty M.empty
-singleNodeLabel pol Codata Nothing xtors = MkNodeLabel pol Nothing (Just xtors) S.empty M.empty M.empty
-singleNodeLabel pol Data (Just tn) xtors   = MkNodeLabel pol Nothing Nothing S.empty (M.singleton tn xtors) M.empty
-singleNodeLabel pol Codata (Just tn) xtors = MkNodeLabel pol Nothing Nothing S.empty M.empty (M.singleton tn xtors)
+singleNodeLabel :: Polarity -> DataCodata -> MonoKind -> Maybe RnTypeName -> Set XtorLabel -> NodeLabel
+singleNodeLabel pol Data mk Nothing xtors   = MkNodeLabel pol (Just xtors) Nothing mk S.empty M.empty M.empty
+singleNodeLabel pol Codata mk Nothing xtors = MkNodeLabel pol Nothing (Just xtors) mk S.empty M.empty M.empty
+singleNodeLabel pol Data mk (Just tn) xtors   = MkNodeLabel pol Nothing Nothing mk S.empty (M.singleton tn xtors) M.empty
+singleNodeLabel pol Codata mk (Just tn) xtors = MkNodeLabel pol Nothing Nothing mk S.empty M.empty (M.singleton tn xtors)
 
 getPolarityNL :: NodeLabel -> Polarity
-getPolarityNL (MkNodeLabel pol _ _ _ _ _) = pol
+getPolarityNL (MkNodeLabel pol _ _ _ _ _ _) = pol
 getPolarityNL (MkPrimitiveNodeLabel pol _) = pol
 
 --------------------------------------------------------------------------------

--- a/src/TypeAutomata/Determinize.hs
+++ b/src/TypeAutomata/Determinize.hs
@@ -88,19 +88,24 @@ combineNodeLabels (fstLabel@MkNodeLabel{}:rs) =
   case rs_merged of
     (MkPrimitiveNodeLabel _ _) -> error "Tried to combine primitive type and algebraic type"
     combLabel@MkNodeLabel{} ->
-      if nl_pol combLabel == pol then
-        MkNodeLabel {
-          nl_pol = pol,
-          nl_data = mrgDat [xtors | MkNodeLabel _ (Just xtors) _ _ _ _ <- [fstLabel,combLabel]],
-          nl_codata = mrgCodat [xtors | MkNodeLabel _ _ (Just xtors) _ _ _ <- [fstLabel,combLabel]],
-          nl_nominal = S.unions [tn | MkNodeLabel _ _ _ tn _ _ <- [fstLabel, combLabel]],
-          nl_ref_data = mrgRefDat [refs | MkNodeLabel _ _ _ _ refs _ <- [fstLabel, combLabel]],
-          nl_ref_codata = mrgRefCodat [refs | MkNodeLabel _ _ _ _ _ refs <- [fstLabel, combLabel]]
-        }
+      if kind == nl_kind combLabel then
+        if nl_pol combLabel == pol then
+          MkNodeLabel {
+            nl_pol = pol,
+            nl_data = mrgDat [xtors | MkNodeLabel _ (Just xtors) _  _ _ _ _ <- [fstLabel,combLabel]],
+            nl_codata = mrgCodat [xtors | MkNodeLabel _ _ (Just xtors) _ _ _ _ <- [fstLabel,combLabel]],
+            nl_kind = kind,
+            nl_nominal = S.unions [tn | MkNodeLabel _ _ _ _ tn _ _ <- [fstLabel, combLabel]],
+            nl_ref_data = mrgRefDat [refs | MkNodeLabel _ _ _ _ _ refs _ <- [fstLabel, combLabel]],
+            nl_ref_codata = mrgRefCodat [refs | MkNodeLabel _ _  _ _ _ _ refs <- [fstLabel, combLabel]]
+          }
+        else
+          error "Tried to combine node labels of different polarity!"
       else
-        error "Tried to combine node labels of different polarity!"
+        error "Tried to combine node labels of different kind!"
   where
     pol = nl_pol fstLabel
+    kind = nl_kind fstLabel
     mrgDat [] = Nothing
     mrgDat (xtor:xtors) = Just $ case pol of {Pos -> S.unions (xtor:xtors) ; Neg -> intersections (xtor :| xtors) }
     mrgCodat [] = Nothing

--- a/src/TypeAutomata/RemoveAdmissible.hs
+++ b/src/TypeAutomata/RemoveAdmissible.hs
@@ -139,8 +139,8 @@ isNotBlacklisted fe = do
 
 subtypeData :: TypeAutCore EdgeLabelNormal -> FlowEdge -> AdmissableM ()
 subtypeData aut@TypeAutCore{ ta_gr } (i,j) = do
-  (MkNodeLabel Neg (Just dat1) _ _  _ _) <- liftAM $ lab ta_gr i
-  (MkNodeLabel Pos (Just dat2) _ _ _ _) <- liftAM $ lab ta_gr j
+  (MkNodeLabel Neg (Just dat1) _ _ _  _ _) <- liftAM $ lab ta_gr i
+  (MkNodeLabel Pos (Just dat2) _ _  _ _ _) <- liftAM $ lab ta_gr j
   -- Check that all constructors in dat1 are also in dat2.
   forM_ (S.toList dat1) $ \xt -> guard (xt `S.member` dat2)
   -- Check arguments of each constructor of dat1.
@@ -154,8 +154,8 @@ subtypeData aut@TypeAutCore{ ta_gr } (i,j) = do
 
 subtypeCodata :: TypeAutCore EdgeLabelNormal -> FlowEdge -> AdmissableM ()
 subtypeCodata aut@TypeAutCore{ ta_gr } (i,j) = do
-  (MkNodeLabel Neg _ (Just codat1) _ _ _ ) <- liftAM $ lab ta_gr i
-  (MkNodeLabel Pos _ (Just codat2) _ _ _ ) <- liftAM $ lab ta_gr j
+  (MkNodeLabel Neg _ (Just codat1) _ _ _ _ ) <- liftAM $ lab ta_gr i
+  (MkNodeLabel Pos _ (Just codat2) _ _ _ _ ) <- liftAM $ lab ta_gr j
   -- Check that all destructors of codat2 are also in codat1.
   forM_ (S.toList codat2) $ \xt -> guard (xt `S.member` codat1)
   -- Check arguments of all destructors of codat2.
@@ -169,8 +169,8 @@ subtypeCodata aut@TypeAutCore{ ta_gr } (i,j) = do
 
 subtypeNominal :: TypeAutCore EdgeLabelNormal -> FlowEdge -> AdmissableM ()
 subtypeNominal TypeAutCore{ ta_gr } (i,j) = do
-  (MkNodeLabel Neg _ _ nominal1 _  _) <- liftAM $ lab ta_gr i
-  (MkNodeLabel Pos _ _ nominal2 _  _) <- liftAM $ lab ta_gr j
+  (MkNodeLabel Neg _ _ _ nominal1 _  _) <- liftAM $ lab ta_gr i
+  (MkNodeLabel Pos _ _ _ nominal2 _  _) <- liftAM $ lab ta_gr j
   guard $ not . S.null $ S.intersection nominal1 nominal2
 
 admissableM :: TypeAutCore EdgeLabelNormal -> FlowEdge -> AdmissableM ()

--- a/src/TypeAutomata/ToAutomaton.hs
+++ b/src/TypeAutomata/ToAutomaton.hs
@@ -189,7 +189,7 @@ sigToLabel (MkXtorSig name ctxt) = MkXtorLabel name (linearContextToArity ctxt)
 insertXtors :: CST.DataCodata -> Polarity -> Maybe RnTypeName -> [XtorSig pol] -> TTA Node
 insertXtors dc pol mtn xtors = do
   newNode <- newNodeM
-  insertNode newNode (singleNodeLabel pol dc mtn (S.fromList (sigToLabel <$> xtors)))
+  insertNode newNode (singleNodeLabel pol dc (CBox CBV) mtn  (S.fromList (sigToLabel <$> xtors)))
   forM_ xtors $ \(MkXtorSig xt ctxt) -> do
     forM_ (enumerate ctxt) $ \(i, pcType) -> do
       node <- insertPCType pcType

--- a/src/TypeInference/Coalescing.hs
+++ b/src/TypeInference/Coalescing.hs
@@ -62,7 +62,7 @@ getOrElseUpdateRecVar ptv = do
 
 
 coalesce :: SolverResult -> Bisubstitution UniVT
-coalesce result@MkSolverResult { tvarSolution } = MkBisubstitution $ M.fromList xs
+coalesce result@MkSolverResult { tvarSolution } = MkBisubstitution (M.fromList xs, M.empty)
     where
         res = M.keys tvarSolution
         f tvar = do x <- coalesceType $ TyUniVar defaultLoc PosRep Nothing tvar

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -39,6 +39,7 @@ data ConstraintInfo
 
 data Constraint a where
   SubType :: a -> Typ Pos -> Typ Neg -> Constraint a
+  KindEq :: a -> MonoKind -> MonoKind -> Constraint a
   TypeClassPos :: a -> ClassName -> Typ Pos -> Constraint a
   TypeClassNeg :: a -> ClassName -> Typ Neg -> Constraint a
     deriving (Eq, Ord, Functor)
@@ -57,6 +58,7 @@ data UVarProvenance
 -- unification variables occurring in them.
 data ConstraintSet = ConstraintSet { cs_constraints :: [Constraint ConstraintInfo]
                                    , cs_uvars :: [(UniTVar, UVarProvenance)]
+                                   , cs_kvars :: [KVar]
                                    }
 
 ------------------------------------------------------------------------------
@@ -73,6 +75,7 @@ data VariableState = VariableState
 emptyVarState :: MonoKind -> VariableState
 emptyVarState = VariableState [] [] []
 
-newtype SolverResult = MkSolverResult
+data SolverResult = MkSolverResult
   { tvarSolution :: Map UniTVar VariableState
+  , kvarSolution :: Map KVar MonoKind
     }

--- a/src/TypeInference/GenerateConstraints/Definition.hs
+++ b/src/TypeInference/GenerateConstraints/Definition.hs
@@ -112,7 +112,7 @@ freshTVar uvp = do
   -- We also need to add the uvar to the constraintset.
   modify (\gs@GenerateState{ constraintSet = cs@ConstraintSet { cs_uvars } } ->
             gs { constraintSet = cs { cs_uvars = cs_uvars ++ [(tvar, uvp)] } })
-  return (TyUniVar defaultLoc PosRep Nothing tvar, TyUniVar defaultLoc NegRep Nothing tvar)
+  return (TyUniVar defaultLoc PosRep (CBox CBV) tvar, TyUniVar defaultLoc NegRep (CBox CBV) tvar)
 
 freshTVars :: [(PrdCns, Maybe FreeVarName)] -> GenM (LinearContext Pos, LinearContext Neg)
 freshTVars [] = return ([],[])

--- a/src/TypeInference/GenerateConstraints/Definition.hs
+++ b/src/TypeInference/GenerateConstraints/Definition.hs
@@ -20,6 +20,7 @@ module TypeInference.GenerateConstraints.Definition
     -- Adding a constraint
   , addConstraint
     -- Other
+  , InferenceMode (..)
   , PrdCnsToPol
   , foo
   , fromMaybeVar
@@ -67,7 +68,7 @@ data GenerateState = GenerateState
   }
 
 initialConstraintSet :: ConstraintSet
-initialConstraintSet = ConstraintSet { cs_constraints = [], cs_uvars = [] }
+initialConstraintSet = ConstraintSet { cs_constraints = [], cs_uvars = [], cs_kvars = []}
 
 initialState :: GenerateState
 initialState = GenerateState { varCount = 0, constraintSet = initialConstraintSet }

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -24,6 +24,7 @@ import Utils
 import Lookup
 import TypeInference.GenerateConstraints.Primitives (primOps)
 import Syntax.RST.Program (ClassDeclaration(classdecl_kinds))
+import Syntax.CST.Kinds
 
 ---------------------------------------------------------------------------------------------
 -- Substitutions and Linear Contexts
@@ -116,8 +117,8 @@ genConstraintsTerm (Core.Xtor loc annot rep CST.Nominal xt subst) = do
   -- and the types we looked up, i.e. the types declared in the XtorSig.
   genConstraintsCtxts substTypes sig_args' (case rep of { PrdRep -> CtorArgsConstraint loc; CnsRep -> DtorArgsConstraint loc })
   case rep of
-    PrdRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc PosRep Nothing (RST.data_name decl) args) CST.Nominal xt substInferred)
-    CnsRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc NegRep Nothing (RST.data_name decl) args) CST.Nominal xt substInferred)
+    PrdRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc PosRep (CBox CBV) (RST.data_name decl) args) CST.Nominal xt substInferred)
+    CnsRep -> return (TST.Xtor loc annot rep (TyNominal defaultLoc NegRep (CBox CBV) (RST.data_name decl) args) CST.Nominal xt substInferred)
 --
 -- Refinement Xtors
 --
@@ -180,8 +181,8 @@ genConstraintsTerm (Core.XCase loc annot rep CST.Nominal cases@(pmcase:_)) = do
                    cmdInferred <- withContext posTypes' (genConstraintsCommand cmdcase_cmd)
                    return (TST.MkCmdCase cmdcase_loc (TST.XtorPat loc' xt args) cmdInferred, MkXtorSig xt negTypes'))
   case rep of
-    PrdRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc PosRep Nothing (RST.data_name decl) args) CST.Nominal (fst <$> inferredCases)
-    CnsRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc NegRep Nothing (RST.data_name decl) args) CST.Nominal (fst <$> inferredCases)
+    PrdRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc PosRep (CBox CBV) (RST.data_name decl) args) CST.Nominal (fst <$> inferredCases)
+    CnsRep -> return $ TST.XCase loc annot rep (TyNominal defaultLoc NegRep (CBox CBV) (RST.data_name decl) args) CST.Nominal (fst <$> inferredCases)
 --
 -- Refinement pattern and copattern matches
 --
@@ -255,7 +256,7 @@ genConstraintsCommand (Core.Print loc prd cmd) = do
   return (TST.Print loc prd' cmd')
 genConstraintsCommand (Core.Read loc cns) = do
   cns' <- genConstraintsTerm cns
-  addConstraint (SubType (ReadConstraint loc)  (TyNominal defaultLoc PosRep Nothing peanoNm []) (TST.getTypeTerm cns'))
+  addConstraint (SubType (ReadConstraint loc)  (TyNominal defaultLoc PosRep (CBox CBV) peanoNm []) (TST.getTypeTerm cns'))
   return (TST.Read loc cns')
 genConstraintsCommand (Core.Apply loc annot t1 t2) = do
   t1' <- genConstraintsTerm t1

--- a/src/TypeTranslation.hs
+++ b/src/TypeTranslation.hs
@@ -94,13 +94,13 @@ translateXtorSigUpper' MkXtorSig{..} = do
 
 -- | Translate a nominal type into a structural type recursively
 translateTypeUpper' :: Typ Neg -> TranslateM (Typ Neg)
-translateTypeUpper' (TyNominal _ NegRep _ tn _) = do
+translateTypeUpper' (TyNominal _ NegRep mk tn _) = do
   m <- asks $ recVarMap . snd
   -- If current type name contained in cache, return corresponding rec. type variable
   if M.member tn m then do
     let tv = fromJust (M.lookup tn m)
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
-    return $ TyRecVar defaultLoc NegRep Nothing tv
+    return $ TyRecVar defaultLoc NegRep mk tv
   else do
     decl <- lookupTypeName defaultLoc tn
     case decl of
@@ -147,13 +147,13 @@ translateXtorSigLower' MkXtorSig{..} = do
 
 -- | Translate a nominal type into a structural type recursively
 translateTypeLower' :: Typ Pos -> TranslateM (Typ Pos)
-translateTypeLower' (TyNominal _ pr _ tn _) = do
+translateTypeLower' (TyNominal _ pr mk tn _) = do
   m <- asks $ recVarMap . snd
   -- If current type name contained in cache, return corresponding rec. type variable
   if M.member tn m then do
     let tv = fromJust (M.lookup tn m)
     modifyVarsUsed $ S.insert tv -- add rec. type variable to used var cache
-    return $ TyRecVar defaultLoc pr Nothing tv
+    return $ TyRecVar defaultLoc pr mk tv
   else do
     decl <- lookupTypeName defaultLoc tn
     case decl of


### PR DESCRIPTION
Polar types will always have a monokind annotated, this is needed for kind inference https://github.com/duo-lang/duo-lang/tree/kindInference
