### PR TITLE
Cache parsing results in Driver

### DIFF
--- a/src/Driver/DepGraph.hs
+++ b/src/Driver/DepGraph.hs
@@ -29,7 +29,7 @@ import Data.Text.Lazy (pack)
 import Parser.Definition ( runFileParser )
 import Parser.Program ( programP )
 import Pretty.Pretty ( ppPrint, ppPrintString )
-import Driver.Definition ( DriverM, findModule )
+import Driver.Definition ( DriverM, findModule, getModuleDeclarations )
 import Resolution.SymbolTable
     ( SymbolTable(imports), createSymbolTable )
 import Syntax.Common.Names ( ModuleName(..) )
@@ -84,9 +84,7 @@ createDepGraph' (mn:mns) depGraph | mn `elem` (visited depGraph) = createDepGrap
                                   | otherwise = do
                                       -- We have to insert the current modulename
                                       let (this, depGraph') = lookupOrInsert depGraph mn
-                                      fp <- findModule mn defaultLoc
-                                      file <- liftIO $ T.readFile fp
-                                      decls <- runFileParser fp programP file
+                                      decls <- getModuleDeclarations mn
                                       symTable <- createSymbolTable mn decls
                                       let importedModules :: [ModuleName] = fst <$> imports symTable
                                       -- We have to insert all the imported module names

--- a/src/Driver/DepGraph.hs
+++ b/src/Driver/DepGraph.hs
@@ -13,7 +13,6 @@ import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.IO qualified as T
 import Data.Maybe (fromJust)
 import Data.List (intersperse)
 import Control.Monad.Except
@@ -26,10 +25,8 @@ import System.FilePath ( (</>), (<.>))
 import System.Directory ( createDirectoryIfMissing, getCurrentDirectory )
 import Data.Text.Lazy (pack)
 
-import Parser.Definition ( runFileParser )
-import Parser.Program ( programP )
 import Pretty.Pretty ( ppPrint, ppPrintString )
-import Driver.Definition ( DriverM, findModule, getModuleDeclarations )
+import Driver.Definition ( DriverM, getModuleDeclarations )
 import Resolution.SymbolTable
     ( SymbolTable(imports), createSymbolTable )
 import Syntax.Common.Names ( ModuleName(..) )

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -262,9 +262,7 @@ runCompilationPlan compilationOrder = forM_ compilationOrder compileModule
     compileModule mn = do
       guardVerbose $ putStrLn ("Compiling module: " <> ppPrintString mn)
       -- 1. Find the corresponding file and parse its contents.
-      fp <- findModule mn defaultLoc
-      file <- liftIO $ T.readFile fp
-      decls <- runFileParser fp programP file
+      decls <- getModuleDeclarations mn
       -- 2. Create a symbol table for the module and add it to the Driver state.
       st <- createSymbolTable mn decls
       addSymboltable mn st

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -15,14 +15,11 @@ import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text qualified as T
-import Data.Text.IO qualified as T
 
 import Driver.Definition
 import Driver.Environment
 import Driver.DepGraph
 import Errors
-import Parser.Definition ( runFileParser )
-import Parser.Program ( programP )
 import Pretty.Pretty ( ppPrint, ppPrintIO, ppPrintString )
 import Resolution.Program (resolveProgram)
 import Resolution.SymbolTable
@@ -47,7 +44,7 @@ import TypeInference.GenerateConstraints.Terms
       genConstraintsTermRecursive,
       genConstraintsInstance )
 import TypeInference.SolveConstraints (solveConstraints)
-import Utils ( Loc, defaultLoc, AttachLoc(attachLoc) )
+import Utils ( Loc, AttachLoc(attachLoc) )
 import Syntax.RST.Types
 import Sugar.Desugar (desugarProgram)
 import qualified Data.Set as S

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -36,16 +36,16 @@ module Parser.Lexer
 import Data.Foldable (asum)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Char (isAlphaNum, isSpace, isPunctuation)
 import Text.Megaparsec hiding (State)
 import Text.Megaparsec.Char
 import Text.Megaparsec.Char.Lexer qualified as L
+import Text.Megaparsec.Char.Lexer (decimal, signed, float)
 
 import Syntax.Common.Names
 import Syntax.Common.Primitives
 import Syntax.CST.Terms qualified as CST
 import Parser.Definition
-import Text.Megaparsec.Char.Lexer (decimal, signed, float)
-import Data.Char (isAlphaNum, isSpace, isPunctuation)
 
 -------------------------------------------------------------------------------------------
 -- General lexing conventions around space consumption and source code locations:

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -13,7 +13,7 @@ import Text.Megaparsec.Pos
 -- Source code locations
 ----------------------------------------------------------------------------------
 
-data Loc = Loc SourcePos SourcePos
+data Loc = Loc !SourcePos !SourcePos
   deriving (Eq, Ord)
 
 instance Show Loc where


### PR DESCRIPTION
Files are parsed (and read from disk) at least twice (once for determining the dependency graph and once for actually returning a program).
Caching this provides a non-negible speedup.
