### PR TITLE
Simplify code actions

### DIFF
--- a/src/Sugar/Desugar.hs
+++ b/src/Sugar/Desugar.hs
@@ -1,6 +1,8 @@
 module Sugar.Desugar
   ( desugarTerm
   , desugarPCTerm
+  , desugarPrdCnsDeclaration
+  , desugarCommandDeclaration
   , desugarProgram
   , desugarCmd
   , desugarEnvironment

--- a/src/Translate/Focusing.hs
+++ b/src/Translate/Focusing.hs
@@ -3,6 +3,8 @@ module Translate.Focusing
   , focusTerm
   , focusCmd
   , focusEnvironment
+  , focusPrdCnsDeclaration
+  , focusCommandDeclaration
   , isFocusedTerm
   , isFocusedCmd
   ) where
@@ -250,6 +252,7 @@ focusCmd eo (PrimOp _ pt op subst) = focusPrimOp eo (pt, op) subst []
 ---------------------------------------------------------------------------------
 -- Lift Focusing to programs
 ---------------------------------------------------------------------------------
+
 focusPrdCnsDeclaration :: EvaluationOrder -> PrdCnsDeclaration pc -> PrdCnsDeclaration pc
 focusPrdCnsDeclaration eo MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcdecl_pc, pcdecl_isRec, pcdecl_name, pcdecl_annot, pcdecl_term } =
     MkPrdCnsDeclaration { pcdecl_loc = pcdecl_loc


### PR DESCRIPTION
The implementation of the code actions manually unpacked the records which contain the information about toplevel declarations, making the implementation much harder to understand than necessary. The new implementation keeps the information contained in the records.