### PR TITLE
Fix whitespace parsing

### DIFF
--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -141,7 +141,8 @@ polyKindP = f <|> g
   where
     f = MkPolyKind [] <$> evalOrderP
     g = do
-      (kindArgs,_) <- parens (tParamP `sepBy` (symbolP SymComma >> sc))
+      (kindArgs,_) <- parensP (tParamP `sepBy` (symbolP SymComma >> sc))
+      sc
       symbolP SymSimpleRightArrow
       sc
       MkPolyKind kindArgs <$> evalOrderP

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -83,6 +83,7 @@ methodNameP = try $ do
 tyOpNameP :: Parser (TyOpName, SourcePos)
 tyOpNameP = try $ do
   (name, pos) <- operatorP
+  sc
   return (MkTyOpName name, pos)
 
 tyBinOpP :: Parser (BinOp, SourcePos)

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -35,38 +35,45 @@ import Syntax.Common.Primitives
 
 freeVarNameP :: Parser (FreeVarName, SourcePos)
 freeVarNameP = try $ do
-  (name, pos) <- lowerCaseId
+  (name, pos) <- lowerCaseIdL
+  sc
   return (MkFreeVarName name, pos)
 
 tvarP :: Parser (SkolemTVar, SourcePos)
 tvarP = try $ do
-  (name, pos) <- lowerCaseId
+  (name, pos) <- lowerCaseIdL
+  sc
   return (MkSkolemTVar name, pos)
 
 
 xtorNameP :: Parser (XtorName, SourcePos)
 xtorNameP = try $ do
-  (name, pos) <- upperCaseId
+  (name, pos) <- upperCaseIdL
+  sc
   return (MkXtorName name, pos)
 
 typeNameP :: Parser (TypeName, SourcePos)
 typeNameP = try $ do
-  (name, pos) <- upperCaseId
+  (name, pos) <- upperCaseIdL
+  sc
   return (MkTypeName name, pos)
 
 moduleNameP :: Parser (ModuleName, SourcePos)
 moduleNameP = try $ do
-  (name, pos) <- upperCaseId
+  (name, pos) <- upperCaseIdL
+  sc
   return (MkModuleName name, pos)
 
 classNameP :: Parser (ClassName, SourcePos)
 classNameP = try $ do
-  (name, pos) <- upperCaseId
+  (name, pos) <- upperCaseIdL
+  sc
   return (MkClassName name, pos)
 
 methodNameP :: Parser (MethodName, SourcePos)
 methodNameP = try $ do
-  (name, pos) <- upperCaseId
+  (name, pos) <- upperCaseIdL
+  sc
   return (MkMethodName name, pos)
 
 ---------------------------------------------------------------------------------

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -105,6 +105,7 @@ tyBinOpP = try (interOp <|> unionOp <|> customOp)
 precedenceP :: Parser Precedence
 precedenceP = do
   (n,_) <- natP
+  sc
   pure (MkPrecedence n)
 
 associativityP :: Parser Associativity

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -110,8 +110,8 @@ precedenceP = do
   pure (MkPrecedence n)
 
 associativityP :: Parser Associativity
-associativityP = (keywordP KwLeftAssoc >> pure LeftAssoc) <|>
-                 (keywordP KwRightAssoc >> pure RightAssoc)
+associativityP = (keywordP KwLeftAssoc  >> sc >> pure LeftAssoc) <|>
+                 (keywordP KwRightAssoc >> sc >> pure RightAssoc)
 
 
 ---------------------------------------------------------------------------------
@@ -119,15 +119,16 @@ associativityP = (keywordP KwLeftAssoc >> pure LeftAssoc) <|>
 ---------------------------------------------------------------------------------
 
 evalOrderP :: Parser EvaluationOrder
-evalOrderP = (keywordP KwCBV $> CBV) <|> (keywordP KwCBN $> CBN)
+evalOrderP = (keywordP KwCBV >> sc >> pure CBV) <|> 
+             (keywordP KwCBN >> sc >> pure CBN)
 
 -- | Parses one of the keywords "CBV" or "CBN"
 monoKindP :: Parser MonoKind
 monoKindP = CBox <$> evalOrderP
-         <|> CRep I64 <$ keywordP KwI64Rep
-         <|> CRep F64 <$ keywordP KwF64Rep
-         <|> CRep PChar <$ keywordP KwCharRep
-         <|> CRep PString <$ keywordP KwStringRep
+         <|> CRep I64 <$ (keywordP KwI64Rep >> sc)
+         <|> CRep F64 <$ (keywordP KwF64Rep >> sc)
+         <|> CRep PChar <$ (keywordP KwCharRep >> sc)
+         <|> CRep PString <$ (keywordP KwStringRep >> sc)
 
 ---------------------------------------------------------------------------------
 -- PolyKinds

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -16,8 +16,10 @@ module Parser.Common
   , evalOrderP
   , monoKindP
   , polyKindP
-  ,methodNameP) where
+  , methodNameP
+  ) where
 
+import Data.Functor ( ($>) )
 import Text.Megaparsec
 
 import Parser.Definition
@@ -25,7 +27,7 @@ import Parser.Lexer
 import Syntax.Common.Names
 import Syntax.CST.Kinds
 import Syntax.Common.Primitives
-import Data.Functor ( ($>) )
+
 
 ---------------------------------------------------------------------------------
 -- Names

--- a/src/Parser/Common.hs
+++ b/src/Parser/Common.hs
@@ -19,7 +19,6 @@ module Parser.Common
   , methodNameP
   ) where
 
-import Data.Functor ( ($>) )
 import Text.Megaparsec
 
 import Parser.Definition

--- a/src/Parser/Definition.hs
+++ b/src/Parser/Definition.hs
@@ -3,14 +3,15 @@ module Parser.Definition
   , runInteractiveParser
   , runFileParser
   , dbg
-  , parseTst) where
+  , parseTst
+  ) where
 
 import Control.Applicative (Alternative)
 import Control.Monad.Except
-import Data.Text qualified as T
-import Data.Void (Void)
 import Data.List.NonEmpty ( NonEmpty )
+import Data.Text qualified as T
 import Data.Text (Text)
+import Data.Void (Void)
 import Text.Megaparsec
 import Text.Megaparsec.Debug qualified
 

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -181,13 +181,11 @@ operatorP = funOperator <|> otherOperator
     funOperator = do
       symbolP SymSimpleRightArrow
       pos <- getSourcePos
-      sc
       pure ("->",pos)
     otherOperator = do
       name <- T.pack <$> many (symbolChar <|> punctuationChar)
       checkReservedOp name
       pos <- getSourcePos
-      sc
       pure (name, pos)
 
 ---

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -108,8 +108,10 @@ scharP = satisfy isSChar <?> "string character"
 
 charP :: Parser (Char, SourcePos)
 charP = do
-  (ch, pos) <- betweenP (symbolP SymSingleQuote) (symbolP SymSingleQuote) scharP
-  return (ch, pos)
+  _ <- symbolP SymSingleQuote
+  ch <- scharP
+  pos <- symbolP SymSingleQuote
+  pure (ch, pos)
 
 stringP :: Parser (String, SourcePos)
 stringP = do
@@ -462,15 +464,30 @@ checkReservedOp str | any (\op -> op `T.isInfixOf` str) (T.pack . show <$> opera
 -- Parens
 -------------------------------------------------------------------------------------------
 
-betweenP :: Parser SourcePos -> Parser SourcePos -> Parser a -> Parser (a, SourcePos)
-betweenP open close middle = do
-  _ <- open
-  res <- middle
-  endPos <- close
+parens :: Parser a -> Parser (a, SourcePos)
+parens parser = do
+  _ <- symbolP SymParenLeft
+  res <- parser
+  endPos <- symbolP SymParenRight
   pure (res, endPos)
 
-parens, braces, brackets, angles :: Parser a -> Parser (a, SourcePos)
-parens    = betweenP (symbolP SymParenLeft)   (symbolP SymParenRight)
-braces    = betweenP (symbolP SymBraceLeft)   (symbolP SymBraceRight)
-brackets  = betweenP (symbolP SymBracketLeft) (symbolP SymBracketRight)
-angles    = betweenP (symbolP SymAngleLeft)   (symbolP SymAngleRight)
+braces :: Parser a -> Parser (a, SourcePos)
+braces parser = do
+  _ <- symbolP SymBraceLeft
+  res <- parser
+  endPos <- symbolP SymBraceRight
+  pure (res, endPos)
+
+brackets :: Parser a -> Parser (a, SourcePos)
+brackets parser = do
+  _ <- symbolP SymBracketLeft
+  res <- parser
+  endPos <- symbolP SymBracketRight
+  pure (res, endPos)
+
+angles :: Parser a -> Parser (a, SourcePos)
+angles parser = do
+  _ <- symbolP SymAngleLeft
+  res <- parser
+  endPos <- symbolP SymAngleRight
+  pure (res, endPos)

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -23,10 +23,10 @@ module Parser.Lexer
   , Symbol(..)
   , symbolP
   -- Parens
-  , angles
-  , parens
-  , brackets
-  , braces
+  , anglesP
+  , parensP
+  , bracketsP
+  , bracesP
   -- Other
   , primOpKeywordP
   , checkTick
@@ -470,42 +470,46 @@ checkReservedOp str | any (\op -> op `T.isInfixOf` str) (T.pack . show <$> opera
 -- Parens
 -------------------------------------------------------------------------------------------
 
-parens :: Parser a -> Parser (a, SourcePos)
-parens parser = do
+-- | The parser provided to `parens` must parse its own trailing whitespace.
+-- The `parens` parser doesn't parse trailing whitespace.
+parensP :: Parser a -> Parser (a, SourcePos)
+parensP parser = do
   symbolP SymParenLeft
   sc
   res <- parser
   symbolP SymParenRight
-  sc
   endPos <- getSourcePos
   pure (res, endPos)
 
-braces :: Parser a -> Parser (a, SourcePos)
-braces parser = do
+-- | The parser provided to `braces` must parse its own trailing whitespace.
+-- The `braces` parser doesn't parse trailing whitespace.
+bracesP :: Parser a -> Parser (a, SourcePos)
+bracesP parser = do
   symbolP SymBraceLeft
   sc
   res <- parser
   symbolP SymBraceRight
-  sc
   endPos <- getSourcePos
   pure (res, endPos)
 
-brackets :: Parser a -> Parser (a, SourcePos)
-brackets parser = do
+-- | The parser provided to `brackets` must parse its own trailing whitespace.
+-- The `brackets` parser doesn't parse trailing whitespace.
+bracketsP :: Parser a -> Parser (a, SourcePos)
+bracketsP parser = do
   symbolP SymBracketLeft
   sc
   res <- parser
   symbolP SymBracketRight
-  sc
   endPos <- getSourcePos
   pure (res, endPos)
 
-angles :: Parser a -> Parser (a, SourcePos)
-angles parser = do
+-- | The parser provided to `angles` must parse its own trailing whitespace.
+-- The `angles` parser doesn't parse trailing whitespace.
+anglesP :: Parser a -> Parser (a, SourcePos)
+anglesP parser = do
   symbolP SymAngleLeft
   sc
   res <- parser
   symbolP SymAngleRight
-  sc
   endPos <- getSourcePos
   pure (res, endPos)

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -462,14 +462,14 @@ checkReservedOp str | any (\op -> op `T.isInfixOf` str) (T.pack . show <$> opera
 -- Parens
 -------------------------------------------------------------------------------------------
 
-betweenP :: Show a => Parser SourcePos -> Parser SourcePos -> Parser a -> Parser (a, SourcePos)
+betweenP :: Parser SourcePos -> Parser SourcePos -> Parser a -> Parser (a, SourcePos)
 betweenP open close middle = do
   _ <- open
   res <- middle
   endPos <- close
   pure (res, endPos)
 
-parens, braces, brackets, angles :: Show a => Parser a -> Parser (a, SourcePos)
+parens, braces, brackets, angles :: Parser a -> Parser (a, SourcePos)
 parens    = betweenP (symbolP SymParenLeft)   (symbolP SymParenRight)
 braces    = betweenP (symbolP SymBraceLeft)   (symbolP SymBraceRight)
 brackets  = betweenP (symbolP SymBracketLeft) (symbolP SymBracketRight)

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -98,7 +98,6 @@ natP :: Parser (Int, SourcePos)
 natP = do
   numStr <- some numberChar
   endPos <- getSourcePos
-  sc
   return (read numStr, endPos)
 
 scharP :: Parser Char

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -377,7 +377,6 @@ primOpKeywordP :: PrimitiveType -> PrimitiveOp -> Parser (PrimitiveType, Primiti
 primOpKeywordP pt op = do
   _ <- string (T.pack (primOpKeyword op ++ primTypeKeyword pt))
   endPos <- getSourcePos
-  sc
   pure (pt, op, endPos)
 
 -------------------------------------------------------------------------------------------

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -12,10 +12,11 @@ module Parser.Lexer
   , uintP
   , floatP
     -- Identifier
-  , lowerCaseId
-  , upperCaseId
+  , lowerCaseIdL
+  , upperCaseIdL
+  , allCaseIdL
+    -- Operators
   , operatorP
-  , allCaseId
   -- Keywords
   , Keyword(..)
   , keywordP
@@ -141,32 +142,39 @@ floatP = do
   pure (f, pos)
 
 -------------------------------------------------------------------------------------------
--- Names
+-- Identifier
 -------------------------------------------------------------------------------------------
 
-lowerCaseId :: Parser (Text, SourcePos)
-lowerCaseId = do
+-- | Parses a lower case identifer, eg `foo`.
+-- Does not parse trailing whitespace.
+lowerCaseIdL :: Parser (Text, SourcePos)
+lowerCaseIdL = do
   name <- T.cons <$> lowerChar <*> (T.pack <$> many alphaNumChar)
   checkReserved name
   pos <- getSourcePos
-  sc
   pure (name, pos)
 
-upperCaseId :: Parser (Text, SourcePos)
-upperCaseId = do
+-- | Parses an upper case identifier, e.g. `Foo`.
+-- Does not parse trailing whitespace.
+upperCaseIdL :: Parser (Text, SourcePos)
+upperCaseIdL = do
   name <- T.cons <$> upperChar <*> (T.pack <$> many alphaNumChar)
   checkReserved name
   pos <- getSourcePos
-  sc
   pure (name, pos)
 
-allCaseId :: Parser (Text, SourcePos)
-allCaseId = do
+-- | Parses an upper or lower case identifier, e.g. `Foo` or `foo`.
+-- Does not parse trailing whitespace.
+allCaseIdL :: Parser (Text, SourcePos)
+allCaseIdL = do
   name <- T.pack <$> many alphaNumChar
   checkReserved name
   pos <- getSourcePos
-  sc
   pure (name, pos)
+
+-------------------------------------------------------------------------------------------
+-- Operators
+-------------------------------------------------------------------------------------------
 
 operatorP :: Parser (Text, SourcePos)
 operatorP = funOperator <|> otherOperator

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -359,9 +359,7 @@ declKeywords = filter isDeclarationKw keywords
 keywordP :: Keyword -> Parser SourcePos
 keywordP kw = do
   _ <- string (T.pack (show kw)) <* notFollowedBy alphaNumChar
-  endPos <- getSourcePos
-  sc
-  return endPos
+  getSourcePos
 
 parseUntilKeywP :: Parser ()
 parseUntilKeywP = do

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -111,7 +111,6 @@ charP = do
   ch <- scharP
   symbolP SymSingleQuote
   pos <- getSourcePos
-  sc
   pure (ch, pos)
 
 stringP :: Parser (String, SourcePos)
@@ -119,7 +118,6 @@ stringP = do
   symbolP SymDoubleQuote
   s <- manyTill scharP (symbolP SymDoubleQuote)
   pos <- getSourcePos
-  sc
   return (s, pos)
 
 uintP :: Parser (Integer, SourcePos)

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -23,7 +23,8 @@ import Syntax.CST.Types
 subtypingProblemP :: Parser (TypeScheme, TypeScheme)
 subtypingProblemP = do
   t1 <- typeSchemeP
-  _ <- symbolP SymSubtype
+  symbolP SymSubtype
+  sc
   t2 <- typeSchemeP
   return (t1,t2)
 

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -21,8 +21,6 @@ import Syntax.CST.Types
 import Syntax.Common.PrdCns
 import Syntax.Common.Names
 import Utils
-import Text.Megaparsec (getSourcePos)
-
 
 recoverDeclaration :: Parser Declaration -> Parser Declaration
 recoverDeclaration = withRecovery (\err -> registerParseError err >> parseUntilKeywP >> return ParseErrorDecl)

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -114,7 +114,8 @@ setDeclP :: Maybe DocComment -> Parser Declaration
 setDeclP doc = do
   startPos <- getSourcePos
   try (void (keywordP KwSet))
-  (txt,_) <- allCaseId
+  (txt,_) <- allCaseIdL
+  sc
   symbolP SymSemi
   endPos <- getSourcePos
   sc

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -197,7 +197,8 @@ dataDeclP doc = do
   recoverDeclaration $ do
     (tn, _pos) <- typeNameP
     knd <- optional (try (symbolP SymColon >> sc) >> polyKindP)
-    (xtors, _pos) <- braces (xtorDeclP `sepBy` (symbolP SymComma >> sc))
+    (xtors, _pos) <- bracesP (xtorDeclP `sepBy` (symbolP SymComma >> sc))
+    sc
     symbolP SymSemi
     endPos <- getSourcePos
     sc
@@ -223,7 +224,10 @@ xtorDeclarationP doc = do
   startPos <- getSourcePos
   dc <- ctorDtorP
   (xt, _) <- xtorNameP
-  args <- optional $ fst <$> (parens (returnP monoKindP `sepBy` (symbolP SymComma >> sc)) <?> "argument list")
+  args <- optional $ do 
+    (args,_) <- parensP (returnP monoKindP `sepBy` (symbolP SymComma >> sc)) <?> "argument list"
+    sc
+    pure args
   ret <- optional (try (symbolP SymColon >> sc) >> evalOrderP)
   symbolP SymSemi
   endPos <- getSourcePos
@@ -247,8 +251,10 @@ classDeclarationP doc = do
   try (void (keywordP KwClass))
   recoverDeclaration $ do
     className     <- fst <$> classNameP
-    typeVars      <- fst <$> parens (tParamP `sepBy` (symbolP SymComma >> sc))
-    (xtors, _pos) <- braces (xtorSignatureP `sepBy` (symbolP SymComma >> sc))
+    typeVars      <- fst <$> parensP (tParamP `sepBy` (symbolP SymComma >> sc))
+    sc
+    (xtors, _pos) <- bracesP (xtorSignatureP `sepBy` (symbolP SymComma >> sc))
+    sc
     symbolP SymSemi
     endPos <- getSourcePos
     sc
@@ -267,7 +273,8 @@ instanceDeclarationP doc = do
   recoverDeclaration $ do
     className  <- fst <$> classNameP
     typ        <- fst <$> typP
-    (cases, _) <- braces ((fst <$> termCaseP) `sepBy` (symbolP SymComma >> sc))
+    (cases, _) <- bracesP ((fst <$> termCaseP) `sepBy` (symbolP SymComma >> sc))
+    sc
     symbolP SymSemi
     endPos <- getSourcePos
     sc

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -196,6 +196,7 @@ primitiveCmdP :: Parser (CST.Term, SourcePos)
 primitiveCmdP = do
   startPos <- getSourcePos
   (pt, op, _) <- asum (uncurry primOpKeywordP <$> keys primOps)
+  sc
   (subst, endPos) <- substitutionP
   pure (CST.PrimCmdTerm $ CST.PrimOp (Loc startPos endPos) pt op subst, endPos)
 

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -265,7 +265,7 @@ patVariableP = do
 -- | Parses a list of patterns in parentheses, or nothing at all: `(pat_1,...,pat_n)`
 patternListP :: Parser ([CST.Pattern], SourcePos)
 patternListP = do
-  s <- optional $ fst <$> parens ((fst <$> patternP) `sepBy` symbolP SymComma)
+  s <- optional $ fst <$> parens ((fst <$> patternP) `sepBy` (symbolP SymComma >> sc))
   endPos <- getSourcePos
   return (Data.Maybe.fromMaybe [] s, endPos)
 

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -104,7 +104,8 @@ natLitP :: CST.NominalStructural -> Parser (CST.Term, SourcePos)
 natLitP ns = do
   startPos <- getSourcePos
   () <- checkTick ns
-  (num, endPos) <- natP <* notFollowedBy (symbolP SymHash >> sc)
+  (num, endPos) <- natP <* notFollowedBy (symbolP SymHash)
+  sc
   return (CST.NatLit (Loc startPos endPos) ns num, endPos)
 
 f64LitP :: Parser (CST.Term, SourcePos)

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -92,12 +92,14 @@ charLitP :: Parser (CST.Term, SourcePos)
 charLitP = do
   startPos <- getSourcePos
   (c, endPos) <- charP
+  sc
   return (CST.PrimLitChar (Loc startPos endPos) c, endPos)
 
 stringLitP :: Parser (CST.Term, SourcePos)
 stringLitP = do
   startPos <- getSourcePos
   (c, endPos) <- stringP
+  sc
   return (CST.PrimLitString (Loc startPos endPos) c, endPos)
 
 natLitP :: CST.NominalStructural -> Parser (CST.Term, SourcePos)

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -116,6 +116,7 @@ f64LitP = do
   (double, endPos) <- try $ do
     (double,_) <- floatP
     endPos <- keywordP KwF64
+    sc
     pure (double, endPos)
   pure (CST.PrimLitF64 (Loc startPos endPos) double, endPos)
 
@@ -125,6 +126,7 @@ i64LitP = do
   (int, endPos) <- try $ do
     (int,_) <- intP
     endPos <- keywordP KwI64
+    sc
     pure (int, endPos)
   pure (CST.PrimLitI64 (Loc startPos endPos) int, endPos)
 
@@ -136,6 +138,7 @@ muAbstraction :: Parser (CST.Term, SourcePos)
 muAbstraction =  do
   startPos <- getSourcePos
   _ <- keywordP KwMu
+  sc
   (v, _pos) <- freeVarNameP
   symbolP SymDot
   sc
@@ -158,18 +161,21 @@ exitSuccessCmdP :: Parser (CST.Term, SourcePos)
 exitSuccessCmdP = do
   startPos <- getSourcePos
   endPos <- keywordP KwExitSuccess
+  sc
   return (CST.PrimCmdTerm $ CST.ExitSuccess (Loc startPos endPos), endPos)
 
 exitFailureCmdP :: Parser (CST.Term, SourcePos)
 exitFailureCmdP = do
   startPos <- getSourcePos
   endPos <- keywordP KwExitFailure
+  sc
   return (CST.PrimCmdTerm $ CST.ExitFailure (Loc startPos endPos), endPos)
 
 printCmdP :: Parser (CST.Term, SourcePos)
 printCmdP = do
   startPos <- getSourcePos
   _ <- keywordP KwPrint
+  sc
   (arg,_) <- parensP (fst <$> termTopP)
   sc
   symbolP SymSemi
@@ -181,6 +187,7 @@ readCmdP :: Parser (CST.Term, SourcePos)
 readCmdP = do
   startPos <- getSourcePos
   _ <- keywordP KwRead
+  sc
   (arg,endPos) <- bracketsP (fst <$> termTopP)
   sc
   return (CST.PrimCmdTerm $ CST.Read (Loc startPos endPos) arg, endPos)
@@ -313,6 +320,7 @@ caseP :: Parser (CST.Term, SourcePos)
 caseP = do
   startPos <- getSourcePos
   _ <- keywordP KwCase
+  sc
   caseRestP startPos <|> caseOfRestP startPos
 
 -- | Parses the second half of a "case" construct, i.e.
@@ -333,6 +341,7 @@ caseOfRestP :: SourcePos -- ^ The source position of the start of the "case" key
 caseOfRestP startPos =  do
   (arg, _pos) <- termTopP
   _ <- keywordP KwOf
+  sc
   (cases, endPos) <- bracesP ((fst <$> termCaseP) `sepBy` (symbolP SymComma >> sc))
   sc
   return (CST.CaseOf (Loc startPos endPos) arg cases, endPos)
@@ -344,6 +353,7 @@ cocaseP :: Parser (CST.Term, SourcePos)
 cocaseP = do
   startPos <- getSourcePos
   _ <- keywordP KwCocase
+  sc
   cocaseRestP startPos <|> cocaseOfRestP startPos
 
 -- | Parses the second half of a "cocase" construct, i.e.
@@ -364,6 +374,7 @@ cocaseOfRestP :: SourcePos -- ^ The source position of the start of the "cocase"
 cocaseOfRestP startPos =  do
   (arg, _pos) <- termTopP
   _ <- keywordP KwOf
+  sc
   (cases, endPos) <- bracesP ((fst <$> termCaseP) `sepBy` (symbolP SymComma >> sc))
   sc
   return (CST.CocaseOf (Loc startPos endPos) arg cases, endPos)

--- a/src/Parser/Types.hs
+++ b/src/Parser/Types.hs
@@ -247,9 +247,9 @@ typeSchemeP = do
 
 typeClassConstraintP :: Parser (Constraint, SourcePos)
 typeClassConstraintP = try $ do
-  cname <- fst <$> upperCaseId
+  (cname,_) <- classNameP
   (tvar, pos) <- tvarP
-  return (TypeClass (MkClassName cname) tvar, pos)
+  return (TypeClass cname tvar, pos)
 
 subTypeConstraintP :: Parser (Constraint, SourcePos)
 subTypeConstraintP = try $ do

--- a/src/Parser/Types.hs
+++ b/src/Parser/Types.hs
@@ -29,7 +29,7 @@ import Utils ( Loc(..) )
 ---------------------------------------------------------------------------------
 returnP :: Parser a -> Parser (PrdCns,a)
 returnP p = do
-  r <- optional (keywordP KwReturn)
+  r <- optional (keywordP KwReturn >> sc)
   b <- p
   return $ case r of
     Just _ -> (Cns,b)
@@ -114,6 +114,7 @@ recTypeP :: Parser (Typ, SourcePos)
 recTypeP = do
   startPos <- getSourcePos
   _ <- keywordP KwRec
+  sc
   (rv,_) <- tvarP
   symbolP SymDot
   sc
@@ -154,6 +155,7 @@ primTypeP :: Keyword -> (Loc -> Typ) -> Parser (Typ, SourcePos)
 primTypeP kw constr = do
   startPos <- getSourcePos
   endPos <- keywordP kw
+  sc
   pure (constr (Loc startPos endPos), endPos)
 
 tyI64P :: Parser (Typ, SourcePos)
@@ -183,12 +185,14 @@ tyTopP :: Parser (Typ, SourcePos)
 tyTopP = do
   startPos <- getSourcePos
   endPos <- keywordP KwTop
+  sc
   pure (TyTop (Loc startPos endPos), endPos)
 
 tyBotP :: Parser (Typ, SourcePos)
 tyBotP = do
   startPos <- getSourcePos
   endPos <- keywordP KwBot
+  sc
   pure (TyBot (Loc startPos endPos), endPos)
 
 -- | Parse atomic types (i,e, without tyop chains)
@@ -239,7 +243,7 @@ typP = do
 typeSchemeP :: Parser TypeScheme
 typeSchemeP = do
   startPos <- getSourcePos
-  tvars' <- option [] (keywordP KwForall >> some (fst <$> tvarP) <* (symbolP SymDot >> sc))
+  tvars' <- option [] (keywordP KwForall >> sc >> some (fst <$> tvarP) <* (symbolP SymDot >> sc))
   let constraintP = fst <$> (typeClassConstraintP <|> subTypeConstraintP)
   tConstraints <- option [] (constraintP `sepBy` (symbolP SymComma >> sc) <* (symbolP SymDoubleRightArrow >> sc))
   (monotype, endPos) <- typP


### PR DESCRIPTION
This PR is about moving the parsing of whitespace (with the explicit whitespace parser `sc`) from the lexer into the parsers for terms, types and programs. The reason for this is that we currently allow way to much whitespace in different places, e.g. between a constructor and the argument list, as in `X  (...)`, or between the producer and destructor in a dtor term `foo . D (...)`. In order to fix the ensuing bugs I first have to make it completely explicit in the term parsers where we are parsing whitespace.