### PR TITLE
Remove primitives from parser

### DIFF
--- a/examples/F64.duo
+++ b/examples/F64.duo
@@ -33,7 +33,7 @@ def prd f2 : F64 := MkF64(f1);
 def prd addf : F64 -> F64 -> F64 := \x => \y =>
     case x of {
         MkF64(x) => case y of {
-           MkF64(y) => mu k. Add#F64(x, y,mu z. MkF64(z) >> k)
+           MkF64(y) => mu k. #F64Add(x, y,mu z. MkF64(z) >> k)
        }
    };
 
@@ -41,7 +41,7 @@ def prd addf : F64 -> F64 -> F64 := \x => \y =>
 def prd subf : F64 -> F64 -> F64 := \x => \y =>
    case x of {
        MkF64(x) => case y of {
-           MkF64(y) => mu k. Sub#F64(x, y,mu z. MkF64(z) >> k)
+           MkF64(y) => mu k. #F64Sub(x, y,mu z. MkF64(z) >> k)
        }
    };
 
@@ -49,7 +49,7 @@ def prd subf : F64 -> F64 -> F64 := \x => \y =>
 def prd mulf : F64 -> F64 -> F64 := \x => \y =>
   case x of {
   MkF64(x) => case y of {
-           MkF64(y) => mu k. Mul#F64(x, y,mu z. MkF64(z) >> k)
+           MkF64(y) => mu k. #F64Mul(x, y,mu z. MkF64(z) >> k)
        }
    };
 
@@ -57,7 +57,7 @@ def prd mulf : F64 -> F64 -> F64 := \x => \y =>
 def prd divf : F64 -> F64 -> F64 := \x => \y =>
    case x of {
         MkF64(x) => case y of {
-           MkF64(y) => mu k. Div#F64(x, y,mu z. MkF64(z) >> k)
+           MkF64(y) => mu k. #F64Div(x, y,mu z. MkF64(z) >> k)
        }
    };
 

--- a/examples/I64.duo
+++ b/examples/I64.duo
@@ -32,7 +32,7 @@ def prd i2 : I64 := MkI64(i1);
 def prd add : I64 -> I64 -> I64 := \x => \y =>
     case x of {
         MkI64(x) => case y of {
-            MkI64(y) => mu k. Add#I64(x, y,mu z. MkI64(z) >> k)
+            MkI64(y) => mu k. #I64Add(x, y,mu z. MkI64(z) >> k)
         }
     };
 
@@ -40,7 +40,7 @@ def prd add : I64 -> I64 -> I64 := \x => \y =>
 def prd sub : I64 -> I64 -> I64 := \x => \y =>
     case x of {
         MkI64(x) => case y of {
-            MkI64(y) => mu k. Sub#I64(x, y,mu z. MkI64(z) >> k)
+            MkI64(y) => mu k. #I64Sub(x, y,mu z. MkI64(z) >> k)
         }
     };
 
@@ -48,7 +48,7 @@ def prd sub : I64 -> I64 -> I64 := \x => \y =>
 def prd mul : I64 -> I64 -> I64 := \x => \y =>
     case x of {
         MkI64(x) => case y of {
-            MkI64(y) => mu k. Mul#I64(x, y,mu z. MkI64(z) >> k)
+            MkI64(y) => mu k. #I64Mul(x, y,mu z. MkI64(z) >> k)
         }
     };
 
@@ -56,7 +56,7 @@ def prd mul : I64 -> I64 -> I64 := \x => \y =>
 def prd div : I64 -> I64 -> I64 := \x => \y =>
     case x of {
         MkI64(x) => case y of {
-            MkI64(y) => mu k. Div#I64(x, y,mu z. MkI64(z) >> k)
+            MkI64(y) => mu k. #I64Div(x, y,mu z. MkI64(z) >> k)
         }
     };
 
@@ -64,6 +64,6 @@ def prd div : I64 -> I64 -> I64 := \x => \y =>
 def prd mod : I64 -> I64 -> I64 := \x => \y =>
     case x of {
         MkI64(x) => case y of {
-            MkI64(y) => mu k. Mod#I64(x, y,mu z. MkI64(z) >> k)
+            MkI64(y) => mu k. #I64Mod(x, y,mu z. MkI64(z) >> k)
         }
     };

--- a/examples/Prelude.duo
+++ b/examples/Prelude.duo
@@ -1,8 +1,8 @@
 -- Standard Prelude
 
-def cmd impossibleCmd := ExitSuccess;
+def cmd impossibleCmd := #ExitSuccess;
 def prd impossiblePrd := mu k. impossibleCmd;
 def cns impossibleCns := mu x. impossibleCmd;
 
 -- | Generic print consumer
-def cns print := mu x.Print(x, ExitSuccess);
+def cns print := mu x.#Print(x, #ExitSuccess);

--- a/examples/Prelude.duo
+++ b/examples/Prelude.duo
@@ -5,4 +5,4 @@ def prd impossiblePrd := mu k. impossibleCmd;
 def cns impossibleCns := mu x. impossibleCmd;
 
 -- | Generic print consumer
-def cns print := mu x.Print(x); ExitSuccess;
+def cns print := mu x.Print(x, ExitSuccess);

--- a/examples/Primitives.duo
+++ b/examples/Primitives.duo
@@ -8,17 +8,6 @@ def prd y := MkI64(2#I64);
 def prd xf := MkF64(7.0#F64);
 def prd yf := MkF64(2.0#F64);
 
-def cmd main :=
-    Print(add x y);
-    Print(sub x y);
-    Print(div x y);
-    Print(mul x y);
-    Print(mod x y);
-    ExitSuccess;
+def cmd main := Print(add x y, Print(sub x y, Print(div x y, Print(mul x y, Print(mod x y, ExitSuccess)))));
 
-def cmd mainf :=
-    Print(addf xf yf);
-    Print(subf xf yf);
-    Print(divf xf yf);
-    Print(mulf xf yf);
-    ExitSuccess;
+def cmd mainf := Print(addf xf yf,Print(subf xf yf,Print(divf xf yf,Print(mulf xf yf,ExitSuccess))));

--- a/examples/Primitives.duo
+++ b/examples/Primitives.duo
@@ -8,6 +8,6 @@ def prd y := MkI64(2#I64);
 def prd xf := MkF64(7.0#F64);
 def prd yf := MkF64(2.0#F64);
 
-def cmd main := Print(add x y, Print(sub x y, Print(div x y, Print(mul x y, Print(mod x y, ExitSuccess)))));
+def cmd main := #Print(add x y, #Print(sub x y, #Print(div x y, #Print(mul x y, #Print(mod x y, #ExitSuccess)))));
 
-def cmd mainf := Print(addf xf yf,Print(subf xf yf,Print(divf xf yf,Print(mulf xf yf,ExitSuccess))));
+def cmd mainf := #Print(addf xf yf,#Print(subf xf yf,#Print(divf xf yf,#Print(mulf xf yf,#ExitSuccess))));

--- a/examples/Sorting.duo
+++ b/examples/Sorting.duo
@@ -84,4 +84,4 @@ def rec prd compare : Nat -> Nat -> Ordering :=
 
 def prd testlist := Cons(5, Cons(2, Cons(8, Cons(1, Cons(4, Cons(7, Cons(3, Cons(6, Cons(10, Cons(9, Nil))))))))));
 
-def cmd main := Print(sort compare testlist); ExitSuccess;
+def cmd main := Print(sort compare testlist, ExitSuccess);

--- a/examples/Sorting.duo
+++ b/examples/Sorting.duo
@@ -84,4 +84,4 @@ def rec prd compare : Nat -> Nat -> Ordering :=
 
 def prd testlist := Cons(5, Cons(2, Cons(8, Cons(1, Cons(4, Cons(7, Cons(3, Cons(6, Cons(10, Cons(9, Nil))))))))));
 
-def cmd main := Print(sort compare testlist, ExitSuccess);
+def cmd main := #Print(sort compare testlist, #ExitSuccess);

--- a/examples/Strings.duo
+++ b/examples/Strings.duo
@@ -36,15 +36,15 @@ def prd helloBoxed : String := MkString(hello);
 def prd append : String -> String -> String :=
   \s => \t => case s of {
     MkString(s) => case t of {
-      MkString(t) => mu k. Append#String(s,t, mu z. MkString(z) >> k)
+      MkString(t) => mu k. #StringAppend(s,t, mu z. MkString(z) >> k)
     }
   };
 
 def prd prepend : Char -> String -> String :=
   \c => \s => case c of {
     MkChar(c) => case s of {
-      MkString(s) => mu k. Prepend#Char(c,s, mu z. MkString(z) >> k)
+      MkString(s) => mu k. #CharPrepend(c,s, mu z. MkString(z) >> k)
     }
   };
 
-def prd hello3 : String := mu k. Prepend#Char('!',"", mu x. Append#String(hello,x,mu z. MkString(z) >> k));
+def prd hello3 : String := mu k. #CharPrepend('!',"", mu x. #StringAppend(hello,x,mu z. MkString(z) >> k));

--- a/examples/TypeClassInstance.duo
+++ b/examples/TypeClassInstance.duo
@@ -26,7 +26,7 @@ class Show(+a : CBV) {
 };
 
 instance Show Bool {
-  Show(x) => Print(x, ExitSuccess)
+  Show(x) => #Print(x, #ExitSuccess)
 };
 
 class Reader(-a : CBV) {
@@ -37,6 +37,6 @@ instance Reader Bool {
   Reader(x, k) => x >> k
 };
 
-def cmd main := Reader(False, case { True => ExitFailure, False => ExitSuccess });
+def cmd main := Reader(False, case { True => #ExitFailure, False => #ExitSuccess });
 
 def prd eq : forall a. Eq a => a -> a -> Bool := \x y => mu k. Equals(x,y,k);

--- a/examples/TypeClassInstance.duo
+++ b/examples/TypeClassInstance.duo
@@ -26,7 +26,7 @@ class Show(+a : CBV) {
 };
 
 instance Show Bool {
-  Show(x) => Print(x); ExitSuccess
+  Show(x) => Print(x, ExitSuccess)
 };
 
 class Reader(-a : CBV) {

--- a/examples/compilertests.duo
+++ b/examples/compilertests.duo
@@ -32,8 +32,8 @@ constructor Succ(CBV);
 constructor Zero;
 
 -- Check subsumption for negative typeschemes
-def cns subsumptionEx1 : < TT > := case { TT => ExitSuccess, FF => ExitSuccess};
-def cns subsumptionEx2 : Nat := mu n. ExitSuccess; 
+def cns subsumptionEx1 : < TT > := case { TT => #ExitSuccess, FF => #ExitSuccess};
+def cns subsumptionEx2 : Nat := mu n. #ExitSuccess; 
 
 
 

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -135,19 +135,19 @@ muAbstraction =  do
 exitSuccessCmdP :: Parser (CST.Term, SourcePos)
 exitSuccessCmdP = do
   startPos <- getSourcePos
-  endPos <- keywordP KwExitSuccess
+  endPos <- try $ symbolP SymHash >> keywordP KwExitSuccess
   return (CST.PrimCmdTerm $ CST.ExitSuccess (Loc startPos endPos), endPos)
 
 exitFailureCmdP :: Parser (CST.Term, SourcePos)
 exitFailureCmdP = do
   startPos <- getSourcePos
-  endPos <- keywordP KwExitFailure
+  endPos <- try $ symbolP SymHash >> keywordP KwExitFailure
   return (CST.PrimCmdTerm $ CST.ExitFailure (Loc startPos endPos), endPos)
 
 printCmdP :: Parser (CST.Term, SourcePos)
 printCmdP = do
   startPos <- getSourcePos
-  _ <- keywordP KwPrint
+  _ <- try $ symbolP SymHash >> keywordP KwPrint
   ((arg, cmd),endPos) <- parensP $ do
     (arg,_) <- term2P
     sc
@@ -161,7 +161,7 @@ printCmdP = do
 readCmdP :: Parser (CST.Term, SourcePos)
 readCmdP = do
   startPos <- getSourcePos
-  _ <- keywordP KwRead
+  _ <- try $ symbolP SymHash >> keywordP KwRead
   (arg,endPos) <- bracketsP (fst <$> term2P)
   return (CST.PrimCmdTerm $ CST.Read (Loc startPos endPos) arg, endPos)
 

--- a/src/Parser/Terms.hs
+++ b/src/Parser/Terms.hs
@@ -148,11 +148,14 @@ printCmdP :: Parser (CST.Term, SourcePos)
 printCmdP = do
   startPos <- getSourcePos
   _ <- keywordP KwPrint
-  (arg,_) <- parensP (fst <$> term2P)
-  sc
-  symbolP SymSemi
-  sc
-  (cmd, endPos) <- term3P
+  ((arg, cmd),endPos) <- parensP $ do
+    (arg,_) <- term2P
+    sc
+    symbolP SymComma
+    sc
+    (cmd,_) <- term3P
+    sc
+    pure (arg, cmd)
   return (CST.PrimCmdTerm $ CST.Print (Loc startPos endPos) arg cmd, endPos)
 
 readCmdP :: Parser (CST.Term, SourcePos)

--- a/src/Pretty/Terms.hs
+++ b/src/Pretty/Terms.hs
@@ -195,9 +195,7 @@ instance PrettyAnn CST.Term where
     annKeyword "ExitFailure"
   prettyAnn (CST.PrimCmdTerm (CST.Print _ t cmd)) =
     annKeyword "Print" <>
-    parens (prettyAnn t) <>
-    semi <+>
-    prettyAnn cmd
+    parens' comma [prettyAnn t, prettyAnn cmd]
   prettyAnn (CST.PrimCmdTerm (CST.Read _ cns)) =
     annKeyword "Read" <>
     brackets (prettyAnn cns)

--- a/src/Pretty/Terms.hs
+++ b/src/Pretty/Terms.hs
@@ -212,20 +212,20 @@ instance PrettyAnn CST.Term where
 ---------------------------------------------------------------------------------
 
 instance PrettyAnn CST.PrimitiveOp where
-  prettyAnn CST.I64Add = "Add#I64"
-  prettyAnn CST.I64Sub = "Sub#I64"
-  prettyAnn CST.I64Mul = "Mul#I64"
-  prettyAnn CST.I64Div = "Div#I64"
-  prettyAnn CST.I64Mod = "Mod#I64"
+  prettyAnn CST.I64Add = "#I64Add"
+  prettyAnn CST.I64Sub = "#I64Sub"
+  prettyAnn CST.I64Mul = "#I64Mul"
+  prettyAnn CST.I64Div = "#I64Div"
+  prettyAnn CST.I64Mod = "#I64Mod"
   -- F64 Ops
-  prettyAnn CST.F64Add = "Add#F64"
-  prettyAnn CST.F64Sub = "Sub#F64"
-  prettyAnn CST.F64Mul = "Mul#F64"
-  prettyAnn CST.F64Div = "Div#F64"
+  prettyAnn CST.F64Add = "#F64Add"
+  prettyAnn CST.F64Sub = "#F64Sub"
+  prettyAnn CST.F64Mul = "#F64Mul"
+  prettyAnn CST.F64Div = "#F64Div"
   -- Char Ops
-  prettyAnn CST.CharPrepend = "Prepend#Char"
+  prettyAnn CST.CharPrepend = "#CharPrepend"
   -- String Ops
-  prettyAnn CST.StringAppend = "Append#String"
+  prettyAnn CST.StringAppend = "#StringAppend"
 
 ---------------------------------------------------------------------------------
 -- Commands

--- a/src/Pretty/Terms.hs
+++ b/src/Pretty/Terms.hs
@@ -190,14 +190,14 @@ instance PrettyAnn CST.Term where
   prettyAnn (CST.NatLit _ CST.Refinement n) =
     prettyAnn (show n)
   prettyAnn (CST.PrimCmdTerm (CST.ExitSuccess _)) =
-    annKeyword "ExitSuccess"
+    annKeyword "#ExitSuccess"
   prettyAnn (CST.PrimCmdTerm (CST.ExitFailure _)) =
-    annKeyword "ExitFailure"
+    annKeyword "#ExitFailure"
   prettyAnn (CST.PrimCmdTerm (CST.Print _ t cmd)) =
-    annKeyword "Print" <>
+    annKeyword "#Print" <>
     parens' comma [prettyAnn t, prettyAnn cmd]
   prettyAnn (CST.PrimCmdTerm (CST.Read _ cns)) =
-    annKeyword "Read" <>
+    annKeyword "#Read" <>
     brackets (prettyAnn cns)
   prettyAnn (CST.Apply _ t1 t2) =
     group (nest 3 (line' <> vsep [parens $ prettyAnn t1, annSymbol ">>", prettyAnn t2]))

--- a/test/counterexamples/CE_011.duo
+++ b/test/counterexamples/CE_011.duo
@@ -4,4 +4,4 @@ data Nat : CBV { Z, S(Nat) };
 data Bool : CBV { True, False };
 codata Fun : CBV { Ap(Nat,Nat) };
 
-def prd fail := Ap(True,mu k.ExitSuccess);
+def prd fail := Ap(True,mu k.#ExitSuccess);

--- a/test/counterexamples/CE_024.duo
+++ b/test/counterexamples/CE_024.duo
@@ -2,4 +2,4 @@
 destructor Ap : CBN;
 constructor True : CBV;
 constructor False : CBV;
-def prd foo : forall a. { Ap(a,a) } := Ap(True,case { True => ExitSuccess, False => ExitSuccess });
+def prd foo : forall a. { Ap(a,a) } := Ap(True,case { True => #ExitSuccess, False => #ExitSuccess });

--- a/test/counterexamples/CE_029.duo
+++ b/test/counterexamples/CE_029.duo
@@ -2,4 +2,4 @@
 
 destructor A : CBV;
 
-def prd test := case { A => ExitSuccess };
+def prd test := case { A => #ExitSuccess };

--- a/test/counterexamples/CE_030.duo
+++ b/test/counterexamples/CE_030.duo
@@ -2,4 +2,4 @@
 
 constructor A : CBV;
 
-def prd test := cocase { A => ExitSuccess };
+def prd test := cocase { A => #ExitSuccess };

--- a/test/counterexamples/CE_037.duo
+++ b/test/counterexamples/CE_037.duo
@@ -2,5 +2,5 @@
 constructor A(CBV) : CBV;
 
 def cns foo := case {
-    A => ExitSuccess
+    A => #ExitSuccess
 };

--- a/test/counterexamples/CE_038.duo
+++ b/test/counterexamples/CE_038.duo
@@ -2,5 +2,5 @@
 destructor A(CBV) : CBV;
 
 def prd foo := cocase {
-    A => ExitSuccess
+    A => #ExitSuccess
 };

--- a/test/counterexamples/CE_039.duo
+++ b/test/counterexamples/CE_039.duo
@@ -2,5 +2,5 @@
 constructor A(CBV) : CBV;
 
 def cns foo := case {
-    A(x,y) => ExitSuccess
+    A(x,y) => #ExitSuccess
 };

--- a/test/counterexamples/CE_040.duo
+++ b/test/counterexamples/CE_040.duo
@@ -2,5 +2,5 @@
 destructor A(CBV) : CBV;
 
 def prd foo := cocase {
-    A(x,y) => ExitSuccess
+    A(x,y) => #ExitSuccess
 };


### PR DESCRIPTION
I want to simplify the parser by removing all the special parsers for `Read, Print, ExitSuccess, ExitFailure Add#I64` etc.

This can be done by just having one grammar production in the syntax:
```
e := ...
   | #Id(e,...,e)   -- Primitives
```
This requires some syntax changes w.r.t to the current syntax. E.g. instead of `ExitSuccess` we have to write `#ExitSuccess` etc. Since we can define toplevel commands it is easy to just define `def exitSuccess := #ExitSuccess;` For the primitive operations that means that we have to rename `Add#I64` to `#I64Add` etc.