### PR TITLE
Add module record

### DIFF
--- a/app/LSP/Handler/CodeAction.hs
+++ b/app/LSP/Handler/CodeAction.hs
@@ -18,7 +18,7 @@ import Dualize.Terms (dualTerm, dualTypeScheme, dualFVName)
 import LSP.Definition ( LSPMonad )
 import LSP.MegaparsecToLSP ( locToRange, lookupPos, locToEndRange )
 import Parser.Definition ( runFileParser )
-import Parser.Program ( programP )
+import Parser.Program ( moduleP )
 import Pretty.Pretty ( ppPrint )
 import Pretty.Program ()
 import Sugar.TST (isDesugaredTerm, isDesugaredCommand, resetAnnotationTerm, resetAnnotationCmd)
@@ -43,7 +43,7 @@ codeActionHandler = requestHandler STextDocumentCodeAction $ \req responder -> d
   let vfile :: VirtualFile = fromMaybe (error "Virtual File not present!") mfile
   let file = virtualFileText vfile
   let fp = fromMaybe "fail" (uriToFilePath uri)
-  let decls = runFileParser fp programP file
+  let decls = runFileParser fp moduleP file
   case decls of
     Left _err -> do
       responder (Right (List []))
@@ -55,8 +55,8 @@ codeActionHandler = requestHandler STextDocumentCodeAction $ \req responder -> d
         Right (_,prog) -> do
           responder (Right (generateCodeActions ident range prog))
 
-generateCodeActions :: TextDocumentIdentifier -> Range -> TST.Program -> List (Command  |? CodeAction)
-generateCodeActions ident rng program = List (join ls)
+generateCodeActions :: TextDocumentIdentifier -> Range -> TST.Module -> List (Command  |? CodeAction)
+generateCodeActions ident rng (TST.MkModule program) = List (join ls)
   where
     ls = generateCodeAction ident rng <$> program
 

--- a/app/LSP/Handler/Hover.hs
+++ b/app/LSP/Handler/Hover.hs
@@ -49,7 +49,7 @@ hoverHandler = requestHandler STextDocumentHover $ \req responder ->  do
     Just cache -> responder (Right (lookupInRangeMap pos cache))
 
 
-updateHoverCache :: Uri -> TST.Program -> LSPMonad ()
+updateHoverCache :: Uri -> TST.Module -> LSPMonad ()
 updateHoverCache uri prog = do
   MkLSPConfig ref <- getConfig
   liftIO $ modifyIORef ref (M.insert uri (toHoverMap prog))
@@ -500,5 +500,5 @@ instance ToHoverMap TST.Declaration where
   toHoverMap (TST.ClassDecl decl)    = toHoverMap decl
   toHoverMap (TST.InstanceDecl decl) = toHoverMap decl
 
-instance ToHoverMap TST.Program where
-  toHoverMap prog = M.unions (toHoverMap <$> prog)
+instance ToHoverMap TST.Module where
+  toHoverMap (TST.MkModule prog) = M.unions (toHoverMap <$> prog)

--- a/app/LSP/Handler/JumpToDef.hs
+++ b/app/LSP/Handler/JumpToDef.hs
@@ -29,7 +29,7 @@ import Driver.Driver ( inferProgramIO )
 import LSP.Definition ( LSPMonad )
 import LSP.MegaparsecToLSP ( locToRange, lookupInRangeMap )
 import Parser.Definition ( runFileParser )
-import Parser.Program ( programP )
+import Parser.Program ( moduleP )
 import Syntax.RST.Terms qualified as RST
 import Syntax.CST.Names
 import Syntax.RST.Types qualified as RST
@@ -44,7 +44,7 @@ jumpToDefHandler = requestHandler STextDocumentDefinition $ \req responder -> do
     let vfile :: VirtualFile = fromMaybe (error "Virtual File not present!") mfile
     let file = virtualFileText vfile
     let fp = fromMaybe "fail" (uriToFilePath uri)
-    let decls = runFileParser fp programP file
+    let decls = runFileParser fp moduleP file
     case decls of
       Left _err -> do
         responder (Left (ResponseError { _code = InvalidRequest, _message = "", _xdata = Nothing}))
@@ -54,10 +54,10 @@ jumpToDefHandler = requestHandler STextDocumentDefinition $ \req responder -> do
           Left _err -> do
             responder (Left (ResponseError { _code = InvalidRequest, _message = "", _xdata = Nothing}))
           Right (_,prog) -> do
-            responder (generateJumpToDef pos (embedCoreProg (embedTSTProg prog)))
+            responder (generateJumpToDef pos (embedCoreModule (embedTSTModule prog)))
 
 
-generateJumpToDef :: Position -> RST.Program -> Either ResponseError (Location |? b)
+generateJumpToDef :: Position -> RST.Module -> Either ResponseError (Location |? b)
 generateJumpToDef pos prog = do
     let jumpMap = toJumpMap prog
     case lookupInRangeMap pos jumpMap of
@@ -201,8 +201,8 @@ instance ToJumpMap (RST.TypeScheme pol) where
 -- Converting programs to a JumpMap
 ---------------------------------------------------------------------------------
 
-instance ToJumpMap RST.Program where
-  toJumpMap prog = M.unions (toJumpMap <$> prog)
+instance ToJumpMap RST.Module where
+  toJumpMap (RST.MkModule prog) = M.unions (toJumpMap <$> prog)
 
 instance ToJumpMap (RST.PrdCnsDeclaration pc) where
   toJumpMap RST.MkPrdCnsDeclaration { pcdecl_term, pcdecl_annot = Nothing } =

--- a/app/LSP/LSP.hs
+++ b/app/LSP/LSP.hs
@@ -36,7 +36,7 @@ import LSP.Handler.JumpToDef ( jumpToDefHandler )
 import LSP.MegaparsecToLSP ( locToRange )
 import Paths_duo_lang (version)
 import Parser.Definition ( runFileParser )
-import Parser.Program ( programP )
+import Parser.Program ( moduleP )
 import Pretty.Pretty ( ppPrint )
 import Pretty.Program ()
 import Utils
@@ -206,7 +206,7 @@ publishErrors uri = do
     Just vfile -> do
       let file = virtualFileText vfile
       let fp = fromMaybe "fail" (uriToFilePath uri)
-      let decls = runExcept (runFileParser fp programP file)
+      let decls = runExcept (runFileParser fp moduleP file)
       case decls of
         Left errs -> do
           sendDiagnostics (toNormalizedUri uri) (NE.toList errs)

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -17,10 +17,10 @@ import Utils ( defaultLoc )
 import Options (DebugFlags(..))
 import Pretty.Errors (printLocatedReport)
 
-driverAction :: ModuleName -> DriverM TST.Program
+driverAction :: ModuleName -> DriverM TST.Module
 driverAction mn = do
   runCompilationModule mn
-  queryTypecheckedProgram mn
+  queryTypecheckedModule mn
 
 
 runRun :: DebugFlags -> ModuleName -> IO ()

--- a/src/Driver/Definition.hs
+++ b/src/Driver/Definition.hs
@@ -20,10 +20,10 @@ import Syntax.TST.Program qualified as TST
 import Utils
 import Control.Monad.Writer
 import Data.Either (rights, lefts)
-import qualified Syntax.CST.Program as CST (Program)
+import qualified Syntax.CST.Program as CST (Module)
 import qualified Data.Text.IO as T
 import Parser.Definition (runFileParser)
-import Parser.Parser (programP)
+import Parser.Parser (moduleP)
 
 ------------------------------------------------------------------------------
 -- Typeinference Options
@@ -63,9 +63,9 @@ data DriverState = MkDriverState
   { drvOpts    :: InferenceOptions
     -- ^ The inference options
   , drvEnv     :: Map ModuleName Environment
-  , drvFiles   :: !(Map ModuleName (FilePath, CST.Program))
+  , drvFiles   :: !(Map ModuleName (FilePath, CST.Module))
   , drvSymbols :: !(Map ModuleName SymbolTable)
-  , drvASTs    :: Map ModuleName TST.Program
+  , drvASTs    :: Map ModuleName TST.Module
   }
 
 defaultDriverState :: DriverState
@@ -107,7 +107,7 @@ getSymbolTables = gets drvSymbols
 
 -- Modules and declarations
 
-getModuleDeclarations :: ModuleName -> DriverM (FilePath, CST.Program)
+getModuleDeclarations :: ModuleName -> DriverM (FilePath, CST.Module)
 getModuleDeclarations mn = do
         moduleMap <- gets drvFiles
         case M.lookup mn moduleMap of
@@ -115,19 +115,19 @@ getModuleDeclarations mn = do
           Nothing -> do
             fp <- findModule mn defaultLoc
             file <- liftIO $ T.readFile fp
-            decls <- runFileParser fp programP file
+            decls <- runFileParser fp moduleP file
             modify (\ds@MkDriverState { drvFiles } -> ds { drvFiles = M.insert mn (fp, decls) drvFiles })
             return (fp, decls)
 
 -- AST Cache
 
-addTypecheckedProgram :: ModuleName -> TST.Program -> DriverM ()
-addTypecheckedProgram mn prog = modify f
+addTypecheckedModule :: ModuleName -> TST.Module -> DriverM ()
+addTypecheckedModule mn prog = modify f
   where
     f state@MkDriverState { drvASTs } = state { drvASTs = M.insert mn prog  drvASTs }
 
-queryTypecheckedProgram :: ModuleName -> DriverM TST.Program
-queryTypecheckedProgram mn = do
+queryTypecheckedModule :: ModuleName -> DriverM TST.Module
+queryTypecheckedModule mn = do
   cache <- gets drvASTs
   case M.lookup mn cache of
     Nothing -> throwOtherError defaultLoc [ "AST for module " <> ppPrint mn <> " not in cache."

--- a/src/Parser/Parser.hs
+++ b/src/Parser/Parser.hs
@@ -3,7 +3,7 @@ module Parser.Parser
   , runInteractiveParser
   , termP
   , declarationP
-  , programP
+  , moduleP
   , typeSchemeP
   , subtypingProblemP
   , Parser

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -1,6 +1,6 @@
 module Parser.Program
   ( declarationP
-  , programP
+  , moduleP
   , returnP
   , xtorDeclP
   , xtorSignatureP
@@ -335,9 +335,9 @@ declarationP = do
   docDeclarationP doc
 
 
-programP :: Parser Program
-programP = do
+moduleP :: Parser Module
+moduleP = do
   sc
   decls <- many declarationP
   eof
-  return decls
+  pure (MkModule decls)

--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -210,11 +210,11 @@ instance PrettyAnn CST.Declaration where
 -- Program
 ---------------------------------------------------------------------------------
 
-instance {-# OVERLAPPING #-} PrettyAnn [TST.Declaration] where
-  prettyAnn decls = vsep (prettyAnn <$> decls)
+instance PrettyAnn CST.Module where
+  prettyAnn (CST.MkModule decls) = vsep (prettyAnn <$> decls)
 
-instance {-# OVERLAPPING #-} PrettyAnn [CST.Declaration] where
-  prettyAnn decls = vsep (prettyAnn <$> decls)
+instance PrettyAnn TST.Module where
+  prettyAnn (TST.MkModule decls) = vsep (prettyAnn <$> decls)
 
 ---------------------------------------------------------------------------------
 -- Prettyprinting of Environments

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -1,4 +1,4 @@
-module Resolution.Program (resolveProgram, resolveDecl) where
+module Resolution.Program (resolveModule, resolveDecl) where
 
 import Control.Monad.Reader
 import Data.List.NonEmpty (NonEmpty((:|)))
@@ -331,5 +331,7 @@ resolveDecl (CST.InstanceDecl decl) = do
 resolveDecl CST.ParseErrorDecl =
   throwOtherError defaultLoc ["Unreachable: ParseErrorDecl cannot be parsed"]
 
-resolveProgram :: CST.Program -> ResolverM RST.Program
-resolveProgram = mapM resolveDecl
+resolveModule :: CST.Module -> ResolverM RST.Module
+resolveModule (CST.MkModule decls) = do
+  decls' <- mapM resolveDecl decls
+  pure (RST.MkModule decls')

--- a/src/Resolution/SymbolTable.hs
+++ b/src/Resolution/SymbolTable.hs
@@ -115,13 +115,13 @@ checkFreshFreeVarName loc fv st =
   else pure ()
 
 
--- | Creating a symbol table for a program.
+-- | Creating a symbol table for a module.
 -- Throws errors if multiple declarations declare the same name.
 createSymbolTable :: MonadError (NonEmpty Error) m
                   => (FilePath, ModuleName)
-                  -> Program
+                  -> Module
                   -> m SymbolTable
-createSymbolTable mn prog = createSymbolTableAcc prog emptySymbolTable
+createSymbolTable mn (MkModule decls) = createSymbolTableAcc decls emptySymbolTable
   where
     createSymbolTableAcc [] acc = pure acc
     createSymbolTableAcc (x:xs) acc = do

--- a/src/Sugar/Desugar.hs
+++ b/src/Sugar/Desugar.hs
@@ -3,7 +3,7 @@ module Sugar.Desugar
   , desugarPCTerm
   , desugarPrdCnsDeclaration
   , desugarCommandDeclaration
-  , desugarProgram
+  , desugarModule
   , desugarCmd
   , desugarEnvironment
   , desugarDecl
@@ -177,8 +177,8 @@ desugarDecl (RST.ClassDecl decl) =
 desugarDecl (RST.InstanceDecl decl) =
   Core.InstanceDecl (desugarInstanceDeclaration decl)
 
-desugarProgram :: RST.Program -> Core.Program
-desugarProgram ps = desugarDecl <$> ps
+desugarModule :: RST.Module -> Core.Module
+desugarModule (RST.MkModule decls) = Core.MkModule (desugarDecl <$> decls)
 
 -- should be resolved, since it's  not actually desugaring anything anymore
 desugarEnvironment :: Map ModuleName Environment -> EvalEnv

--- a/src/Syntax/CST/Program.hs
+++ b/src/Syntax/CST/Program.hs
@@ -283,4 +283,9 @@ data Declaration where
 instance Show Declaration where
   show _ = "<Show for Declaration not implemented>"
 
-type Program = [Declaration]
+---------------------------------------------------------------------------------
+-- Module
+---------------------------------------------------------------------------------
+
+newtype Module = MkModule { mod_decls :: [Declaration] } deriving (Show)
+

--- a/src/Syntax/Core/Program.hs
+++ b/src/Syntax/Core/Program.hs
@@ -100,5 +100,9 @@ instance Show Declaration where
   show (TySynDecl         decl) = show decl
   show (ClassDecl         decl) = show decl
   show (InstanceDecl      decl) = show decl
-  
-type Program = [Declaration]
+
+---------------------------------------------------------------------------------
+-- Module
+---------------------------------------------------------------------------------
+
+newtype Module = MkModule { mod_decls :: [Declaration] } deriving (Show)

--- a/src/Syntax/RST/Program.hs
+++ b/src/Syntax/RST/Program.hs
@@ -249,5 +249,8 @@ instance Show Declaration where
   show (ClassDecl         decl) = show decl
   show (InstanceDecl      decl) = show decl
 
-  
-type Program = [Declaration]
+---------------------------------------------------------------------------------
+-- Module
+---------------------------------------------------------------------------------
+
+newtype Module = MkModule { mod_decls :: [Declaration] } deriving (Show)

--- a/src/Syntax/TST/Program.hs
+++ b/src/Syntax/TST/Program.hs
@@ -101,5 +101,9 @@ instance Show Declaration where
   show (TySynDecl         decl) = show decl
   show (ClassDecl         decl) = show decl
   show (InstanceDecl      decl) = show decl
-  
-type Program = [Declaration]
+
+---------------------------------------------------------------------------------
+-- Module
+---------------------------------------------------------------------------------
+
+newtype Module = MkModule { mod_decls :: [Declaration] } deriving (Show)

--- a/src/Translate/Embed.hs
+++ b/src/Translate/Embed.hs
@@ -92,8 +92,8 @@ embedCoreCommand (Core.PrimOp loc op subst) =
     RST.PrimOp loc op (embedSubst subst)
 
 
-embedCoreProg :: Core.Program -> RST.Program
-embedCoreProg = fmap embedCoreDecl
+embedCoreModule :: Core.Module -> RST.Module
+embedCoreModule (Core.MkModule decls ) = RST.MkModule (embedCoreDecl <$> decls)
 
 embedPrdCnsDeclaration :: Core.PrdCnsDeclaration pc -> RST.PrdCnsDeclaration pc
 embedPrdCnsDeclaration Core.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcdecl_pc, pcdecl_isRec, pcdecl_name, pcdecl_annot, pcdecl_term } =
@@ -206,8 +206,8 @@ embedTSTCommand (TST.ExitFailure loc) =
 embedTSTCommand (TST.PrimOp loc op subst) =
     Core.PrimOp loc op (embedTSTSubst subst)
 
-embedTSTProg :: TST.Program -> Core.Program
-embedTSTProg = fmap embedTSTDecl
+embedTSTModule :: TST.Module -> Core.Module
+embedTSTModule (TST.MkModule decls) = Core.MkModule (embedTSTDecl <$> decls)
 
 embedTSTPrdCnsDecl :: TST.PrdCnsDeclaration pc -> Core.PrdCnsDeclaration pc
 embedTSTPrdCnsDecl TST.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcdecl_pc, pcdecl_isRec, pcdecl_name, pcdecl_annot = RST.Annotated tys, pcdecl_term } =

--- a/src/Translate/Focusing.hs
+++ b/src/Translate/Focusing.hs
@@ -1,5 +1,5 @@
 module Translate.Focusing
-  ( focusProgram
+  ( focusModule
   , focusTerm
   , focusCmd
   , focusEnvironment
@@ -292,8 +292,8 @@ focusDecl _  decl@TySynDecl {}       = decl
 focusDecl _  decl@ClassDecl {}       = decl
 focusDecl eo (InstanceDecl decl)     = InstanceDecl (focusInstanceDeclaration eo decl)
 
-focusProgram :: EvaluationOrder -> Program -> Program
-focusProgram eo = fmap (focusDecl eo)
+focusModule :: EvaluationOrder -> Module -> Module
+focusModule eo (MkModule decls) = MkModule (focusDecl eo <$> decls)
 
 focusEnvironment :: EvaluationOrder -> EvalEnv -> EvalEnv
 focusEnvironment cc (prd, cns, cmd) = (prd', cns', cmd')

--- a/src/Translate/Reparse.hs
+++ b/src/Translate/Reparse.hs
@@ -3,7 +3,7 @@ module Translate.Reparse
   , reparsePCTerm
   , reparseCommand
   , reparseDecl
-  , reparseProgram
+  , reparseModule
   , reparseSubst
   , reparseSubstI
   , reparseCmdCase
@@ -690,5 +690,5 @@ reparseDecl (RST.ClassDecl decl) =
 reparseDecl (RST.InstanceDecl decl) =
   CST.InstanceDecl (reparseInstanceDecl decl)
 
-reparseProgram :: RST.Program -> CST.Program
-reparseProgram = fmap reparseDecl
+reparseModule :: RST.Module -> CST.Module
+reparseModule (RST.MkModule decls) = CST.MkModule (reparseDecl <$> decls)

--- a/test/Spec/Focusing.hs
+++ b/test/Spec/Focusing.hs
@@ -21,7 +21,7 @@ type Reason = String
 pendingFiles :: [(FilePath, Reason)]
 pendingFiles = []
 
-testHelper :: (FilePath, Either (NonEmpty Error) TST.Program) -> EvaluationOrder -> SpecWith ()
+testHelper :: (FilePath, Either (NonEmpty Error) TST.Module) -> EvaluationOrder -> SpecWith ()
 testHelper (example,decls) cbx = describe (show cbx ++ " Focusing the program in  " ++ example ++ " typechecks.") $ 
   case example `lookup` pendingFiles of
     Just reason -> it "" $ pendingWith $ "Could not focus file " ++ example ++ "\nReason: " ++ reason
@@ -29,14 +29,14 @@ testHelper (example,decls) cbx = describe (show cbx ++ " Focusing the program in
       case decls of
         Left err -> it "Could not read in example " $ expectationFailure (ppPrintString err)
         Right decls -> do
-          let focusedDecls :: CST.Program = reparseProgram $ embedCoreProg $ embedTSTProg $ focusProgram cbx decls
+          let focusedDecls :: CST.Module = reparseModule $ embedCoreModule $ embedTSTModule $ focusModule cbx decls
           res <- runIO $ inferProgramIO defaultDriverState "" focusedDecls
           case res of
             (Left err,_) -> do
               let msg = unlines [ "---------------------------------"
                                 , "Prettyprinted declarations:"
                                 , ""
-                                ,  ppPrintString (focusProgram cbx decls)
+                                ,  ppPrintString (focusModule cbx decls)
                                 , ""
                                 , "Show instance of declarations:"
                                 , ""
@@ -50,7 +50,7 @@ testHelper (example,decls) cbx = describe (show cbx ++ " Focusing the program in
               it "Could not load examples" $ expectationFailure msg
             (Right _env,_) -> pure ()
 
-spec :: [(FilePath,Either (NonEmpty Error) TST.Program)] -> Spec
+spec :: [(FilePath,Either (NonEmpty Error) TST.Module)] -> Spec
 spec examples = do
     describe "Focusing an entire program still typechecks" $ do
       forM_ examples $ \example -> do

--- a/test/Spec/LocallyClosed.hs
+++ b/test/Spec/LocallyClosed.hs
@@ -19,23 +19,23 @@ type Reason = String
 pendingFiles :: [(FilePath, Reason)]
 pendingFiles = []
 
-getProducers :: TST.Program -> [(FreeVarName, Term Prd)]
-getProducers prog = go prog []
+getProducers :: TST.Module -> [(FreeVarName, Term Prd)]
+getProducers (TST.MkModule decls)= go decls []
   where
-    go :: TST.Program -> [(FreeVarName, Term Prd)] -> [(FreeVarName, Term Prd)]
+    go :: [TST.Declaration] -> [(FreeVarName, Term Prd)] -> [(FreeVarName, Term Prd)]
     go [] acc = acc
     go ((TST.PrdCnsDecl PrdRep (TST.MkPrdCnsDeclaration _ _ PrdRep _ fv _ tm)):rest) acc = go rest ((fv,tm):acc)
     go (_:rest) acc = go rest acc
 
-getInstanceCases :: TST.Program -> [InstanceCase]
-getInstanceCases prog = go prog []
+getInstanceCases :: TST.Module -> [InstanceCase]
+getInstanceCases (TST.MkModule decls) = go decls []
   where
-    go :: TST.Program -> [InstanceCase] -> [InstanceCase]
+    go :: [TST.Declaration] -> [InstanceCase] -> [InstanceCase]
     go [] acc = acc
     go ((TST.InstanceDecl (TST.MkInstanceDeclaration _ _ _ _ cases)):rest) acc = go rest (cases++acc)
     go (_:rest) acc = go rest acc
 
-spec :: [(FilePath, Either (NonEmpty Error) TST.Program)] -> Spec
+spec :: [(FilePath, Either (NonEmpty Error) TST.Module)] -> Spec
 spec examples = do
   describe "All examples are locally closed." $ do
     forM_ examples $ \(example, eitherEnv) -> do

--- a/test/Spec/Prettyprinter.hs
+++ b/test/Spec/Prettyprinter.hs
@@ -25,8 +25,8 @@ pendingFiles = []
 -- 2. Prettyprinted
 -- 3a. Parsed again from the prettyprinted result.
 -- 3b. Parsed and typechecked again from the prettyprinted result.
-spec :: [(FilePath, Either (NonEmpty Error) CST.Program)] -- ^ examples to be parsed after pretty-printing
-  -> [(FilePath, Either (NonEmpty Error) TST.Program)] -- ^ examples to be type-checked after pretty-printing
+spec :: [(FilePath, Either (NonEmpty Error) CST.Module)] -- ^ examples to be parsed after pretty-printing
+  -> [(FilePath, Either (NonEmpty Error) TST.Module)] -- ^ examples to be type-checked after pretty-printing
   -> Spec
 spec parseExamples typeCheckExamples = do
   describe "All the examples in the \"examples/\" folder can be parsed after prettyprinting." $ do
@@ -35,7 +35,7 @@ spec parseExamples typeCheckExamples = do
         it "Can be parsed again." $
           case prog of
             Left err -> expectationFailure (ppPrintString err)
-            Right decls -> runFileParser example programP (ppPrint decls) `shouldSatisfy` isRight
+            Right decls -> runFileParser example moduleP (ppPrint decls) `shouldSatisfy` isRight
 
   describe "All the examples in the \"examples/\" folder can be parsed and typechecked after prettyprinting." $ do
     forM_ typeCheckExamples $ \(example,prog) -> do
@@ -44,7 +44,7 @@ spec parseExamples typeCheckExamples = do
          Nothing     -> describe ("The example " ++ example ++ " can be parsed and typechecked after prettyprinting.") $ do
             case prog of
                 Left err -> it "Can be parsed and typechecked again." $ expectationFailure (ppPrintString err)
-                Right decls -> case runFileParser example programP (ppPrint decls) of
+                Right decls -> case runFileParser example moduleP (ppPrint decls) of
                   Left _ -> it "Can be parsed and typechecked again." $ expectationFailure "Could not be parsed"
                   Right decls -> do
                     res <- runIO $ inferProgramIO defaultDriverState "" decls

--- a/test/Spec/TypeInferenceExamples.hs
+++ b/test/Spec/TypeInferenceExamples.hs
@@ -16,8 +16,8 @@ pendingFiles = [ ("test/counterexamples/CE_053.duo", "Constraint Solver for type
                ]
 
 -- | Typecheck the programs in the toplevel "examples/" subfolder.
-spec :: [(FilePath, Either (NonEmpty Error) CST.Program)]
-     -> [(FilePath, Either (NonEmpty Error) TST.Program)]
+spec :: [(FilePath, Either (NonEmpty Error) CST.Module)]
+     -> [(FilePath, Either (NonEmpty Error) TST.Module)]
      -> Spec
 spec counterExamplesParsed counterExamplesChecked = do
   describe "All the programs in the \"test/counterexamples/\" folder can be parsed." $ do

--- a/test/TestRunner.hs
+++ b/test/TestRunner.hs
@@ -15,7 +15,7 @@ import Driver.Definition (defaultDriverState)
 import Driver.Driver (inferProgramIO)
 import Errors
 import Parser.Definition (runFileParser)
-import Parser.Program (programP)
+import Parser.Program (moduleP)
 import Resolution.SymbolTable (SymbolTable, createSymbolTable)
 import Spec.LocallyClosed qualified
 import Spec.TypeInferenceExamples qualified
@@ -53,14 +53,14 @@ getAvailableExamples = do
   examples <- listDirectory "examples/"
   return (("examples/" ++) <$> filter (\s -> head s /= '.' && notElem s excluded) examples)
 
-getParsedDeclarations :: FilePath -> IO (Either (NonEmpty Error) CST.Program)
+getParsedDeclarations :: FilePath -> IO (Either (NonEmpty Error) CST.Module)
 getParsedDeclarations fp = do
   s <- T.readFile fp
-  case runExcept (runFileParser fp programP s) of
+  case runExcept (runFileParser fp moduleP s) of
     Left err -> pure (Left err)
     Right prog -> pure (pure prog)
 
-getTypecheckedDecls :: FilePath -> IO (Either (NonEmpty Error) TST.Program)
+getTypecheckedDecls :: FilePath -> IO (Either (NonEmpty Error) TST.Module)
 getTypecheckedDecls fp = do
   decls <- getParsedDeclarations fp
   case decls of


### PR DESCRIPTION
Instead of
```haskell
type Program = [Declaration]
```
we have
```haskell
newtype Module = MkModule { mod_decls :: [Declaration] }
```
We also need to track the filepath and the module name in the module itself, but not in this PR.