### PR TITLE
Add infix operators with backtick syntax

### DIFF
--- a/examples/Function.duo
+++ b/examples/Function.duo
@@ -6,9 +6,14 @@ codata Fun : (-a : CBV, +b : CBV) -> CBN {
 };
 
 type operator -> rightassoc at 0 := Fun;
+type operator `to` rightassoc at 0 := Fun;
 
 -- | The polymorphic identity function
 def prd id : forall a. a -> a :=
+  \x => x;
+
+-- | The polymorphic identity function
+def prd idTo : forall a. a `to` a :=
   \x => x;
 
 -- | Function composition

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -179,7 +179,7 @@ allCaseIdL = do
 -------------------------------------------------------------------------------------------
 
 operatorP :: Parser (Text, SourcePos)
-operatorP = funOperator <|> otherOperator
+operatorP = funOperator <|> otherOperator <|> backtickOperator
   where
     -- We have to treat the function arrow specially, since we want to allow it
     -- as an operator, but it is also a reserved symbol.
@@ -192,6 +192,12 @@ operatorP = funOperator <|> otherOperator
       checkReservedOp name
       pos <- getSourcePos
       pure (name, pos)
+    backtickOperator = do
+      symbolP SymBacktick
+      name <- T.pack <$> many alphaNumChar
+      symbolP SymBacktick
+      pos <- getSourcePos
+      pure ("`" <> name <> "`", pos)
 
 ---
 

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -179,7 +179,7 @@ allCaseIdL = do
 -------------------------------------------------------------------------------------------
 
 operatorP :: Parser (Text, SourcePos)
-operatorP = funOperator <|> otherOperator <|> backtickOperator
+operatorP = backtickOperator <|> funOperator <|> otherOperator
   where
     -- We have to treat the function arrow specially, since we want to allow it
     -- as an operator, but it is also a reserved symbol.

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -390,6 +390,7 @@ data Symbol where
   SymPlus             :: Symbol
   SymMinus            :: Symbol
   SymHash             :: Symbol
+  SymBacktick         :: Symbol
   -- Parens Symbols
   SymParenLeft        :: Symbol
   SymParenRight       :: Symbol
@@ -424,6 +425,7 @@ instance Show Symbol where
   show SymPlus             = "+"
   show SymMinus            = "-"
   show SymHash             = "#"
+  show SymBacktick         = "`"
   -- Parens Symbols
   show SymParenLeft        = "("
   show SymParenRight       = ")"


### PR DESCRIPTION
This allows to parse the following kind of type operators:

```
type operator `throws` leftassoc at 3 := Par
```

Which allows for the following cute syntax which mimicks Java:

```
def prd throw : forall a. a -> Bot `throws` a :=
  \x -> cocase { MkPar(_, k_err => x >> k_err };
```