### PR TITLE
Allow underscore in Identifiers

### DIFF
--- a/examples/LinearLogic.duo
+++ b/examples/LinearLogic.duo
@@ -121,11 +121,11 @@ type operator ⅋ leftassoc at 3 := Par;
 
 -- | Injection into the right element of Par.
 def prd unit : forall a. a -> Bot ⅋ a :=
-  \x => cocase { MkPar(kerr,*) => x };
+  \x => cocase { MkPar(k_err,*) => x };
 
 -- | Injection into the left element of Par.
 def prd throw : forall a. a -> a ⅋ Bot :=
-  \x => cocase { MkPar(*,kres) => x };
+  \x => cocase { MkPar(*,k_res) => x };
 
 --------------------------------------------------------------------------------------------
 -- Negation as a data type

--- a/src/Parser/Lexer.hs
+++ b/src/Parser/Lexer.hs
@@ -151,7 +151,7 @@ floatP = do
 -- Does not parse trailing whitespace.
 lowerCaseIdL :: Parser (Text, SourcePos)
 lowerCaseIdL = do
-  name <- T.cons <$> lowerChar <*> (T.pack <$> many alphaNumChar)
+  name <- T.cons <$> lowerChar <*> (T.pack <$> many (alphaNumChar <|> char '_'))
   checkReserved name
   pos <- getSourcePos
   pure (name, pos)
@@ -160,7 +160,7 @@ lowerCaseIdL = do
 -- Does not parse trailing whitespace.
 upperCaseIdL :: Parser (Text, SourcePos)
 upperCaseIdL = do
-  name <- T.cons <$> upperChar <*> (T.pack <$> many alphaNumChar)
+  name <- T.cons <$> upperChar <*> (T.pack <$> many (alphaNumChar <|> char '_'))
   checkReserved name
   pos <- getSourcePos
   pure (name, pos)
@@ -169,7 +169,7 @@ upperCaseIdL = do
 -- Does not parse trailing whitespace.
 allCaseIdL :: Parser (Text, SourcePos)
 allCaseIdL = do
-  name <- T.pack <$> many alphaNumChar
+  name <- T.cons <$> alphaNumChar <*> (T.pack <$> many (alphaNumChar <|> char '_'))
   checkReserved name
   pos <- getSourcePos
   pure (name, pos)


### PR DESCRIPTION
Allow to use underscores in identifier names. Especially useful for the name of continuation variables like `k_error` vs `k_success`.