### PR TITLE
Fix error prettyprinting

### DIFF
--- a/src/Pretty/Errors.hs
+++ b/src/Pretty/Errors.hs
@@ -32,17 +32,29 @@ import Syntax.CST.Types (PrdCns(..))
 
 instance PrettyAnn ResolutionError where
   prettyAnn (MissingVarsInTypeScheme loc) =
-    prettyAnn loc <+> "Missing declaration of type variable"
+    vsep [ prettyAnn loc
+         , "Missing declaration of type variable."
+         ]
   prettyAnn (TopInPosPolarity loc) =
-    prettyAnn loc <+> "Cannot use `Top` in positive polarity"
-  prettyAnn (BotInNegPolarity loc) = 
-    prettyAnn loc <+> "Cannot use `Bot` in negative polarity"
+    vsep [ prettyAnn loc
+         , "Cannot use `Top` in positive polarity."
+         ]
+  prettyAnn (BotInNegPolarity loc) =
+    vsep [ prettyAnn loc
+         , "Cannot use `Bot` in negative polarity."
+         ]
   prettyAnn (IntersectionInPosPolarity loc) =
-    prettyAnn loc <+> "Cannot use `/\\` in positive polarity"
+    vsep [ prettyAnn loc
+         , "Cannot use `/\\` in positive polarity"
+         ]
   prettyAnn (UnionInNegPolarity loc) = 
-    prettyAnn loc <+> "Cannot use `\\/` in negative polarity"
+    vsep [ prettyAnn loc
+         , "Cannot use `\\/` in negative polarity"
+         ]
   prettyAnn (UnknownOperator loc op) =
-    prettyAnn loc <+> "Undefined type operator `" <> pretty op <> "`"
+    vsep [ prettyAnn loc
+         , "Undefined type operator `" <> pretty op <> "`"
+         ]
   prettyAnn (XtorArityMismatch loc xt ar1 ar2) =
     vsep [ prettyAnn loc
          , "Arity mismatch:"
@@ -64,9 +76,13 @@ instance PrettyAnn ResolutionError where
          , "  Used Arity:" <+> pretty ar1
          ]
   prettyAnn (CmdExpected loc t) =
-    prettyAnn loc <+> "Command expected: " <+> pretty t
+    vsep [ prettyAnn loc
+         , "Command expected: " <+> pretty t
+         ]
   prettyAnn (InvalidStar loc t) =
-    prettyAnn loc <+> "Invalid Star: " <+> pretty t
+    vsep [ prettyAnn loc
+         , "Invalid Star: " <+> pretty t
+         ]
 
 instance PrettyAnn ConstraintGenerationError where
   prettyAnn (BoundVariableOutOfBounds loc rep (i,j)) =
@@ -129,23 +145,33 @@ instance PrettyAnn ConstraintGenerationError where
 
 instance PrettyAnn ConstraintSolverError where
   prettyAnn (SomeConstraintSolverError loc msg) =
-    prettyAnn loc <> "Constraint solver error:" <+> pretty msg
+    vsep [ prettyAnn loc
+         , "Constraint solver error:" <+> pretty msg
+         ]
 
 instance PrettyAnn TypeAutomatonError where
   prettyAnn (SomeTypeAutomatonError loc msg) =
-    prettyAnn loc <> "Type automaton error:" <+> pretty msg
+    vsep [ prettyAnn loc
+         , "Type automaton error:" <+> pretty msg
+         ]
 
 instance PrettyAnn EvalError where
   prettyAnn (SomeEvalError loc msg) =
-    prettyAnn loc <> "Evaluation error:" <+> pretty msg
+    vsep [ prettyAnn loc
+         , "Evaluation error:" <+> pretty msg
+         ]
 
 instance PrettyAnn OtherError where
   prettyAnn (SomeOtherError loc msg) =
-    prettyAnn loc <> "Other error:" <+> pretty msg
+    vsep [ prettyAnn loc
+         , "Other error:" <+> pretty msg
+         ]
 
 instance PrettyAnn ParserError where
   prettyAnn (SomeParserError loc msg) =
-    prettyAnn loc <> "Parser error:" <+> pretty msg
+    vsep [ prettyAnn loc
+         , "Parser error:" <+> pretty msg
+         ]
 
 instance PrettyAnn Error where
   prettyAnn (ErrConstraintGeneration err)   = prettyAnn err

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -4,9 +4,10 @@ import Control.Monad.Reader
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Text qualified as T
+
 
 import Errors
+import Pretty.Pretty ( ppPrint )
 import Resolution.Definition
 import Resolution.SymbolTable
 import Resolution.Terms (resolveTerm, resolveCommand, resolveInstanceCases)
@@ -23,6 +24,7 @@ import Syntax.CST.Names
 import Utils (Loc, defaultLoc)
 
 
+
 ---------------------------------------------------------------------------------
 -- Data Declarations
 ---------------------------------------------------------------------------------
@@ -36,14 +38,17 @@ resolveXtors sigs = do
 
 checkVarianceTyp :: Loc -> Variance -> PolyKind -> CST.Typ -> ResolverM ()
 checkVarianceTyp _ _ tv(CST.TyUniVar loc _) =
-  throwOtherError loc ["The Unification Variable " <> T.pack (show  tv) <> " should not appear in the program at this point"]
+  throwOtherError loc ["The Unification Variable " <> ppPrint tv <> " should not appear in the program at this point"]
 checkVarianceTyp _ var polyKind (CST.TySkolemVar loc tVar) =
   case lookupPolyKindVariance tVar polyKind of
     -- The following line does not work correctly if the data declaration contains recursive types in the arguments of an xtor.
-    Nothing   -> throwOtherError loc ["Type variable not bound by declaration: " <> T.pack (show tVar)]
+    Nothing   -> throwOtherError loc ["Type variable not bound by declaration: " <> ppPrint tVar]
     Just var' -> if var == var'
                  then return ()
-                 else throwOtherError loc ["Variance mismatch for variable " <> T.pack (show tVar) <> ":\nFound: " <> T.pack (show var) <> "\nRequired: " <> T.pack (show var')]
+                 else throwOtherError loc ["Variance mismatch for variable " <> ppPrint tVar <> ":"
+                                          , "Found: " <> ppPrint var
+                                          , "Required: " <> ppPrint var'
+                                          ]
 checkVarianceTyp loc var polyKind (CST.TyXData _loc' dataCodata  xtorSigs) = do
   let var' = var <> case dataCodata of
                       CST.Data   -> Covariant
@@ -63,8 +68,8 @@ checkVarianceTyp loc var polyKind (CST.TyNominal _loc' tyName tys) = do
     go (v:vs) (t:ts)  = do
       checkVarianceTyp loc (v <> var) polyKind t
       go vs ts
-    go [] (_:_)       = throwOtherError loc ["Type Constructor " <> T.pack (show tyName) <> " is applied to too many arguments"]
-    go (_:_) []       = throwOtherError loc ["Type Constructor " <> T.pack (show tyName) <> " is applied to too few arguments"]
+    go [] (_:_)       = throwOtherError loc ["Type Constructor " <> ppPrint tyName <> " is applied to too many arguments"]
+    go (_:_) []       = throwOtherError loc ["Type Constructor " <> ppPrint tyName <> " is applied to too few arguments"]
 checkVarianceTyp loc var polyKind (CST.TyRec _loc' _tVar ty) =
   checkVarianceTyp loc var polyKind ty
 checkVarianceTyp _loc _var _polyKind (CST.TyTop _loc') = return ()

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -37,7 +37,7 @@ resolveXtors sigs = do
 checkVarianceTyp :: Loc -> Variance -> PolyKind -> CST.Typ -> ResolverM ()
 checkVarianceTyp _ _ tv(CST.TyUniVar loc _) =
   throwOtherError loc ["The Unification Variable " <> T.pack (show  tv) <> " should not appear in the program at this point"]
-checkVarianceTyp loc var polyKind (CST.TySkolemVar _loc' tVar) =
+checkVarianceTyp _ var polyKind (CST.TySkolemVar loc tVar) =
   case lookupPolyKindVariance tVar polyKind of
     -- The following line does not work correctly if the data declaration contains recursive types in the arguments of an xtor.
     Nothing   -> throwOtherError loc ["Type variable not bound by declaration: " <> T.pack (show tVar)]


### PR DESCRIPTION
Fix prettyprinting of errors:
- newlines after the loc
- pretty instance instead of show instance
- more precise error location for one specific error.