### PR TITLE
Add benchmark suite

### DIFF
--- a/bench/BenchRunner.hs
+++ b/bench/BenchRunner.hs
@@ -10,13 +10,8 @@ import Driver.Driver (inferProgramIO)
 import Errors
 import Parser.Definition (runFileParser)
 import Parser.Program (moduleP)
-import Resolution.SymbolTable (SymbolTable, createSymbolTable)
 import Syntax.CST.Program qualified as CST
 import Syntax.TST.Program qualified as TST
-import Options.Applicative
-import Utils (listRecursiveDuoFiles)
-
-
 import Utils ( listRecursiveDuoFiles )
 
 excluded :: [FilePath]

--- a/bench/BenchRunner.hs
+++ b/bench/BenchRunner.hs
@@ -1,4 +1,55 @@
 module Main where
 
+import Criterion.Main
+
+import Control.Monad.Except
+import Data.List.NonEmpty (NonEmpty)
+import Data.Text.IO qualified as T
+import Driver.Definition (defaultDriverState)
+import Driver.Driver (inferProgramIO)
+import Errors
+import Parser.Definition (runFileParser)
+import Parser.Program (moduleP)
+import Resolution.SymbolTable (SymbolTable, createSymbolTable)
+import Syntax.CST.Program qualified as CST
+import Syntax.TST.Program qualified as TST
+import Options.Applicative
+import Utils (listRecursiveDuoFiles)
+
+
+import Utils ( listRecursiveDuoFiles )
+
+excluded :: [FilePath]
+excluded = ["fix.duo"]
+
+getAvailableExamples :: IO [FilePath]
+getAvailableExamples = do
+  examples <- listRecursiveDuoFiles "examples/"
+  examples' <- listRecursiveDuoFiles "std/"
+  return (filter (\s -> head s /= '.' && notElem s excluded) (examples <> examples'))
+
+getParsedDeclarations :: FilePath -> IO (Either (NonEmpty Error) CST.Module)
+getParsedDeclarations fp = do
+  s <- T.readFile fp
+  case runExcept (runFileParser fp (moduleP fp) s) of
+    Left err -> pure (Left err)
+    Right prog -> pure (pure prog)
+
+getTypecheckedDecls :: FilePath -> IO (Either (NonEmpty Error) TST.Module)
+getTypecheckedDecls fp = do
+  decls <- getParsedDeclarations fp
+  case decls of
+    Right decls -> do
+      fmap snd <$> (fst <$> inferProgramIO defaultDriverState decls)
+    Left err -> return (Left err)
+
+typeInferenceBenchmarks :: [FilePath] -> Benchmark
+typeInferenceBenchmarks fps = bgroup "Type inference" (inferType <$> fps)
+
+inferType :: FilePath -> Benchmark
+inferType fp = bench ("Example: " <> fp) $ whnfIO (getTypecheckedDecls fp)
+
 main :: IO ()
-main = putStrLn "Benchmarks not implemented"
+main = do
+    examples <- getAvailableExamples
+    defaultMain [typeInferenceBenchmarks examples]

--- a/bench/BenchRunner.hs
+++ b/bench/BenchRunner.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Benchmarks not implemented"

--- a/duo-lang.cabal
+++ b/duo-lang.cabal
@@ -247,5 +247,6 @@ Benchmark duo-lang-bench
   hs-source-dirs:
       bench
   build-depends:
-      duo-lang
+      duo-lang,
+      criterion
 

--- a/duo-lang.cabal
+++ b/duo-lang.cabal
@@ -235,4 +235,17 @@ test-suite duo-lang-test
       test
   build-depends:
       duo-lang
+  
+Benchmark duo-lang-bench
+  import: shared-build-depends
+  import: app-build-depends
+  import: shared-lang-options
+  import: shared-ghc-opts
+  import: shared-rts-opts
+  type: exitcode-stdio-1.0
+  main-is: BenchRunner.hs
+  hs-source-dirs:
+      bench
+  build-depends:
+      duo-lang
 


### PR DESCRIPTION
Simplest possible benchmark suite. We should refine later, it also currently takes quite a while to run through on my office computer.

```
duo-lang> benchmarks
Running 1 benchmarks...
Benchmark duo-lang-bench: RUNNING...
benchmarking Type inference/Example: examples/TypeClassInstance.duo
time                 88.60 ms   (86.55 ms .. 89.73 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 90.71 ms   (89.62 ms .. 95.34 ms)
std dev              3.106 ms   (436.6 μs .. 5.367 ms)
                      
benchmarking Type inference/Example: examples/ParserAlt.duo
time                 239.1 ms   (238.5 ms .. 240.5 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 237.8 ms   (236.9 ms .. 238.4 ms)
std dev              917.2 μs   (572.2 μs .. 1.300 ms)
variance introduced by outliers: 16% (moderately inflated)
                      
benchmarking Type inference/Example: examples/DeMorgan.duo
time                 211.0 ms   (203.6 ms .. 225.8 ms)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 210.3 ms   (206.3 ms .. 215.4 ms)
std dev              5.569 ms   (3.782 ms .. 7.487 ms)
variance introduced by outliers: 14% (moderately inflated)
                      
benchmarking Type inference/Example: examples/VexingParse.duo
time                 86.15 ms   (82.34 ms .. 88.84 ms)
                     0.994 R²   (0.981 R² .. 1.000 R²)
mean                 87.74 ms   (86.42 ms .. 91.70 ms)
std dev              3.878 ms   (1.032 ms .. 6.530 ms)
                      
benchmarking Type inference/Example: examples/tutorial.duo
time                 1.182 ms   (1.172 ms .. 1.193 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 1.210 ms   (1.192 ms .. 1.280 ms)
std dev              102.1 μs   (19.83 μs .. 207.9 μs)
variance introduced by outliers: 64% (severely inflated)
                      
benchmarking Type inference/Example: examples/Shifts.duo
time                 138.6 μs   (137.0 μs .. 140.5 μs)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 144.1 μs   (141.5 μs .. 146.9 μs)
std dev              9.524 μs   (7.826 μs .. 11.22 μs)
variance introduced by outliers: 64% (severely inflated)
                      
benchmarking Type inference/Example: examples/Parser.duo
time                 218.8 ms   (215.7 ms .. 221.7 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 219.9 ms   (218.6 ms .. 221.6 ms)
std dev              1.829 ms   (1.129 ms .. 2.634 ms)
variance introduced by outliers: 14% (moderately inflated)
                      
benchmarking Type inference/Example: examples/Subsumption.duo
time                 91.91 ms   (90.23 ms .. 93.32 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 93.23 ms   (92.42 ms .. 94.50 ms)
std dev              1.570 ms   (820.7 μs .. 2.057 ms)
                      
benchmarking Type inference/Example: examples/Primitives.duo
time                 108.0 ms   (106.4 ms .. 110.1 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 109.8 ms   (108.9 ms .. 111.6 ms)
std dev              2.007 ms   (841.5 μs .. 3.355 ms)
                      
benchmarking Type inference/Example: examples/Callcc.duo
time                 53.74 ms   (53.06 ms .. 54.30 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 53.86 ms   (53.43 ms .. 54.83 ms)
std dev              1.278 ms   (446.9 μs .. 2.352 ms)
                      
benchmarking Type inference/Example: examples/icfp/ParsimoniousFilter.duo
time                 185.3 ms   (180.9 ms .. 189.8 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 184.2 ms   (183.1 ms .. 185.3 ms)
std dev              1.512 ms   (945.5 μs .. 1.956 ms)
variance introduced by outliers: 14% (moderately inflated)
                      
benchmarking Type inference/Example: examples/icfp/icfp22example.duo
time                 109.3 ms   (108.5 ms .. 110.6 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 108.6 ms   (107.9 ms .. 109.1 ms)
std dev              882.2 μs   (460.7 μs .. 1.328 ms)
                      
benchmarking Type inference/Example: examples/TypeClasses.duo
time                 141.7 ms   (138.7 ms .. 144.2 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 140.1 ms   (139.4 ms .. 141.1 ms)
std dev              1.098 ms   (603.9 μs .. 1.691 ms)
variance introduced by outliers: 12% (moderately inflated)
                      
benchmarking Type inference/Example: examples/compilertests.duo
time                 121.9 ms   (119.8 ms .. 123.3 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 124.2 ms   (123.2 ms .. 126.9 ms)
std dev              2.340 ms   (640.2 μs .. 3.583 ms)
variance introduced by outliers: 11% (moderately inflated)
                      
benchmarking Type inference/Example: examples/Prelude.duo
time                 178.1 μs   (174.9 μs .. 183.2 μs)
                     0.995 R²   (0.989 R² .. 0.999 R²)
mean                 181.3 μs   (178.5 μs .. 184.9 μs)
std dev              11.07 μs   (8.089 μs .. 14.18 μs)
variance introduced by outliers: 59% (severely inflated)
                      
benchmarking Type inference/Example: examples/Ord.duo
time                 58.44 ms   (58.08 ms .. 59.03 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 57.71 ms   (57.42 ms .. 58.01 ms)
std dev              559.3 μs   (454.3 μs .. 699.7 μs)
                      
benchmarking Type inference/Example: examples/Sorting.duo
time                 290.0 ms   (287.6 ms .. 293.0 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 287.3 ms   (285.4 ms .. 288.6 ms)
std dev              1.978 ms   (678.9 μs .. 2.849 ms)
variance introduced by outliers: 16% (moderately inflated)
                      
benchmarking Type inference/Example: std/Codata/VoidN.duo
time                 41.94 μs   (40.17 μs .. 43.93 μs)
                     0.989 R²   (0.983 R² .. 0.997 R²)
mean                 41.50 μs   (40.60 μs .. 43.17 μs)
std dev              3.787 μs   (2.504 μs .. 5.178 μs)
variance introduced by outliers: 81% (severely inflated)
                      
benchmarking Type inference/Example: std/Codata/NegationN.duo
time                 62.25 μs   (59.79 μs .. 65.37 μs)
                     0.989 R²   (0.984 R² .. 0.999 R²)
mean                 61.77 μs   (60.56 μs .. 63.44 μs)
std dev              4.809 μs   (3.098 μs .. 6.270 μs)
variance introduced by outliers: 74% (severely inflated)
                      
benchmarking Type inference/Example: std/Codata/With.duo
time                 47.41 ms   (40.61 ms .. 53.75 ms)
                     0.956 R²   (0.932 R² .. 0.984 R²)
mean                 36.81 ms   (34.48 ms .. 40.56 ms)
std dev              6.098 ms   (4.459 ms .. 7.701 ms)
variance introduced by outliers: 65% (severely inflated)
                      
benchmarking Type inference/Example: std/Codata/Par.duo
time                 31.52 ms   (29.13 ms .. 36.94 ms)
                     0.959 R²   (0.926 R² .. 0.987 R²)
mean                 34.90 ms   (33.33 ms .. 37.60 ms)
std dev              4.532 ms   (3.006 ms .. 6.552 ms)
variance introduced by outliers: 54% (severely inflated)
                      
benchmarking Type inference/Example: std/Codata/Stream.duo
time                 250.5 ms   (171.3 ms .. 298.8 ms)
                     0.934 R²   (0.826 R² .. 1.000 R²)
mean                 222.7 ms   (203.1 ms .. 249.9 ms)
std dev              28.77 ms   (19.38 ms .. 37.80 ms)
variance introduced by outliers: 32% (moderately inflated)
                      
benchmarking Type inference/Example: std/Codata/UnitN.duo
time                 39.50 μs   (38.50 μs .. 40.63 μs)
                     0.991 R²   (0.987 R² .. 0.996 R²)
mean                 40.59 μs   (39.67 μs .. 42.07 μs)
std dev              4.111 μs   (3.157 μs .. 6.489 μs)
variance introduced by outliers: 84% (severely inflated)
                      
benchmarking Type inference/Example: std/Codata/Function.duo
time                 7.469 ms   (7.319 ms .. 7.608 ms)
                     0.997 R²   (0.992 R² .. 0.999 R²)
mean                 7.426 ms   (7.347 ms .. 7.683 ms)
std dev              346.5 μs   (149.4 μs .. 671.7 μs)
variance introduced by outliers: 22% (moderately inflated)
                      
benchmarking Type inference/Example: std/Prim/F64.duo
time                 62.98 ms   (61.81 ms .. 64.75 ms)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 62.96 ms   (62.18 ms .. 63.69 ms)
std dev              1.402 ms   (1.019 ms .. 1.934 ms)
                      
benchmarking Type inference/Example: std/Prim/I64.duo
time                 33.33 ms   (32.44 ms .. 33.99 ms)
                     0.995 R²   (0.987 R² .. 0.999 R²)
mean                 34.27 ms   (33.78 ms .. 35.35 ms)
std dev              1.457 ms   (652.6 μs .. 2.337 ms)
variance introduced by outliers: 12% (moderately inflated)
                      
benchmarking Type inference/Example: std/Prim/Strings.duo
time                 61.13 ms   (59.39 ms .. 64.70 ms)
                     0.996 R²   (0.990 R² .. 1.000 R²)
mean                 60.09 ms   (59.24 ms .. 61.30 ms)
std dev              1.973 ms   (1.306 ms .. 3.188 ms)
                      
benchmarking Type inference/Example: std/Data/Unit.duo
time                 40.42 μs   (39.05 μs .. 42.08 μs)
                     0.989 R²   (0.984 R² .. 0.995 R²)
mean                 40.79 μs   (39.85 μs .. 42.11 μs)
std dev              3.754 μs   (3.082 μs .. 4.603 μs)
variance introduced by outliers: 81% (severely inflated)
                      
benchmarking Type inference/Example: std/Data/BoolRefinement.duo
time                 34.65 ms   (33.32 ms .. 35.72 ms)
                     0.993 R²   (0.985 R² .. 0.999 R²)
mean                 35.64 ms   (34.92 ms .. 37.80 ms)
std dev              2.326 ms   (857.3 μs .. 4.085 ms)
variance introduced by outliers: 24% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/NegationP.duo
time                 61.49 μs   (60.65 μs .. 62.73 μs)
                     0.996 R²   (0.992 R² .. 0.999 R²)
mean                 62.57 μs   (61.48 μs .. 64.06 μs)
std dev              4.662 μs   (2.954 μs .. 6.109 μs)
variance introduced by outliers: 73% (severely inflated)
                      
benchmarking Type inference/Example: std/Data/List.duo
time                 114.6 ms   (111.6 ms .. 119.4 ms)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 114.6 ms   (113.5 ms .. 116.7 ms)
std dev              2.406 ms   (1.129 ms .. 3.478 ms)
variance introduced by outliers: 11% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/PeanoRefinement.duo
time                 67.47 ms   (63.81 ms .. 72.29 ms)
                     0.994 R²   (0.982 R² .. 1.000 R²)
mean                 65.81 ms   (64.33 ms .. 67.50 ms)
std dev              2.877 ms   (2.420 ms .. 3.489 ms)
                      
benchmarking Type inference/Example: std/Data/Peano.duo
time                 75.15 ms   (67.31 ms .. 90.59 ms)
                     0.935 R²   (0.808 R² .. 0.999 R²)
mean                 72.30 ms   (67.77 ms .. 82.06 ms)
std dev              10.84 ms   (3.995 ms .. 16.64 ms)
variance introduced by outliers: 48% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/Cofunction.duo
time                 1.576 ms   (1.523 ms .. 1.647 ms)
                     0.981 R²   (0.969 R² .. 0.993 R²)
mean                 1.637 ms   (1.571 ms .. 1.832 ms)
std dev              343.2 μs   (145.5 μs .. 720.6 μs)
variance introduced by outliers: 91% (severely inflated)
                      
benchmarking Type inference/Example: std/Data/BoolStructural.duo
time                 39.05 ms   (35.86 ms .. 42.86 ms)
                     0.982 R²   (0.961 R² .. 0.999 R²)
mean                 36.90 ms   (36.22 ms .. 38.31 ms)
std dev              2.053 ms   (1.002 ms .. 3.332 ms)
variance introduced by outliers: 19% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/PeanoStructural.duo
time                 70.93 ms   (61.30 ms .. 83.62 ms)
                     0.931 R²   (0.787 R² .. 0.989 R²)
mean                 74.26 ms   (69.61 ms .. 79.43 ms)
std dev              9.336 ms   (6.913 ms .. 12.58 ms)
variance introduced by outliers: 44% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/Tensor.duo
time                 31.86 ms   (29.28 ms .. 34.22 ms)
                     0.985 R²   (0.973 R² .. 0.994 R²)
mean                 33.94 ms   (32.53 ms .. 36.51 ms)
std dev              3.532 ms   (1.580 ms .. 6.057 ms)
variance introduced by outliers: 42% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/Plus.duo
time                 36.02 ms   (33.52 ms .. 39.05 ms)
                     0.982 R²   (0.952 R² .. 0.997 R²)
mean                 36.58 ms   (35.28 ms .. 38.48 ms)
std dev              3.009 ms   (2.107 ms .. 4.172 ms)
variance introduced by outliers: 30% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/Void.duo
time                 38.69 μs   (37.20 μs .. 41.22 μs)
                     0.974 R²   (0.960 R² .. 0.989 R²)
mean                 41.77 μs   (39.60 μs .. 44.04 μs)
std dev              8.096 μs   (5.877 μs .. 11.66 μs)
variance introduced by outliers: 95% (severely inflated)
                      
benchmarking Type inference/Example: std/Data/Bool.duo
time                 39.79 ms   (37.27 ms .. 42.27 ms)
                     0.987 R²   (0.973 R² .. 0.998 R²)
mean                 38.08 ms   (37.33 ms .. 39.13 ms)
std dev              1.849 ms   (1.106 ms .. 2.756 ms)
variance introduced by outliers: 13% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/BinaryTree.duo
time                 193.1 ms   (158.1 ms .. 222.7 ms)
                     0.973 R²   (0.918 R² .. 1.000 R²)
mean                 182.6 ms   (173.0 ms .. 191.2 ms)
std dev              13.07 ms   (8.056 ms .. 16.62 ms)
variance introduced by outliers: 15% (moderately inflated)
                      
benchmarking Type inference/Example: std/Data/Maybe.duo
time                 62.50 ms   (55.28 ms .. 72.40 ms)
                     0.960 R²   (0.905 R² .. 0.988 R²)
mean                 75.49 ms   (69.48 ms .. 81.28 ms)
std dev              10.32 ms   (8.570 ms .. 13.76 ms)
variance introduced by outliers: 44% (moderately inflated)
                      
Benchmark duo-lang-bench: FINISH
Completed 2 action(s).
```