### PR TITLE
Simplify unresolve

### DIFF
--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -42,7 +42,7 @@ instance PrettyAnn CST.DataDecl where
     semi
 
 instance PrettyAnn RST.DataDecl where
-  prettyAnn decl = prettyAnn (unresolve decl)
+  prettyAnn decl = prettyAnn (runUnresolveM (unresolve decl))
 
 ---------------------------------------------------------------------------------
 -- Producer / Consumer Declarations
@@ -191,7 +191,7 @@ instance PrettyAnn TST.Declaration where
   prettyAnn decl = prettyAnn (embedTST decl)
 
 instance PrettyAnn RST.Declaration where
-  prettyAnn decl = prettyAnn (unresolve decl)
+  prettyAnn decl = prettyAnn (runUnresolveM (unresolve decl))
 
     
 instance PrettyAnn CST.Declaration where

--- a/src/Pretty/Terms.hs
+++ b/src/Pretty/Terms.hs
@@ -50,12 +50,12 @@ instance PrettyAnn TST.CmdCase where
   prettyAnn cmdcase = prettyAnn (embedTST cmdcase)
 
 instance PrettyAnn RST.CmdCase where
-  prettyAnn cmdcase = prettyAnn (unresolve cmdcase)
+  prettyAnn cmdcase = prettyAnn (runUnresolveM (unresolve cmdcase))
 
 -- TermCase
 
 instance PrettyAnn (RST.TermCase pc) where
-  prettyAnn termcase = prettyAnn (unresolve termcase)
+  prettyAnn termcase = prettyAnn (runUnresolveM (unresolve termcase))
 
 instance PrettyAnn CST.TermCase where
   prettyAnn CST.MkTermCase{ tmcase_pat, tmcase_term } =
@@ -64,7 +64,7 @@ instance PrettyAnn CST.TermCase where
       prettyAnn tmcase_term
 
 instance PrettyAnn (RST.TermCaseI pc) where
-  prettyAnn termcasei = prettyAnn (unresolve termcasei)
+  prettyAnn termcasei = prettyAnn (runUnresolveM (unresolve termcasei))
 
 instance PrettyAnn CST.TermOrStar  where
   prettyAnn (CST.ToSTerm t) = prettyAnn t
@@ -80,7 +80,7 @@ instance PrettyAnn TST.PrdCnsTerm where
   prettyAnn pcterm = prettyAnn (embedCore (embedTST pcterm))
 
 instance PrettyAnn RST.PrdCnsTerm where
-  prettyAnn pcterm = prettyAnn (unresolve pcterm)
+  prettyAnn pcterm = prettyAnn (runUnresolveM (unresolve pcterm))
 
 -- Substitution
 
@@ -88,7 +88,7 @@ instance {-# OVERLAPPING #-} PrettyAnn TST.Substitution where
   prettyAnn subst = prettyAnn (embedCore (embedTST subst))
 
 instance {-# OVERLAPPING #-} PrettyAnn RST.Substitution where
-  prettyAnn subst = prettyAnn (unresolve subst)
+  prettyAnn subst = prettyAnn (runUnresolveM (unresolve subst))
 
 instance PrettyAnn CST.Substitution where
   prettyAnn (CST.MkSubstitution subst) = parens' comma (prettyAnn <$> subst)
@@ -96,7 +96,7 @@ instance PrettyAnn CST.Substitution where
 -- SubstitutionI
 
 instance PrettyAnn (RST.SubstitutionI pc) where
-  prettyAnn substi = prettyAnn (unresolve substi)
+  prettyAnn substi = prettyAnn (runUnresolveM (unresolve substi))
 
 instance PrettyAnn CST.SubstitutionI where
   prettyAnn (CST.MkSubstitutionI substi) = parens' comma (prettyAnn <$> substi)
@@ -110,7 +110,7 @@ instance PrettyAnn (TST.Term pc) where
   prettyAnn tm = prettyAnn (embedTST tm)
 
 instance PrettyAnn (RST.Term pc) where
-  prettyAnn tm = prettyAnn (unresolve tm)
+  prettyAnn tm = prettyAnn (runUnresolveM (unresolve tm))
 
 instance PrettyAnn (Core.Term pc) where
   prettyAnn tm = prettyAnn (embedCore tm)
@@ -204,7 +204,7 @@ instance PrettyAnn TST.Command where
   prettyAnn cmd = prettyAnn (embedTST cmd)
 
 instance PrettyAnn RST.Command where
-  prettyAnn cmd = prettyAnn (unresolve cmd)
+  prettyAnn cmd = prettyAnn (runUnresolveM (unresolve cmd))
 
 instance PrettyAnn Core.Command where
   prettyAnn cmd = prettyAnn (embedCore cmd)

--- a/src/Pretty/Types.hs
+++ b/src/Pretty/Types.hs
@@ -10,7 +10,7 @@ import Syntax.RST.Types qualified as RST
 import Syntax.CST.Types qualified as CST
 import Syntax.TST.Types qualified as TST
 import Syntax.CST.Names
-import Resolution.Unresolve (Unresolve (..))
+import Resolution.Unresolve (Unresolve (..), runUnresolveM)
 import Translate.EmbedTST (EmbedTST(..))
 
 ---------------------------------------------------------------------------------
@@ -86,10 +86,10 @@ instance PrettyAnn CST.DataCodata where
 ---------------------------------------------------------------------------------
 
 instance PrettyAnn (RST.VariantType pol) where
-  prettyAnn varType = prettyAnn (unresolve varType)
+  prettyAnn varType = prettyAnn (runUnresolveM (unresolve varType))
 
 instance PrettyAnn (RST.PrdCnsType pol) where
-  prettyAnn pctype = prettyAnn (unresolve pctype)
+  prettyAnn pctype = prettyAnn (runUnresolveM (unresolve pctype))
 
 instance PrettyAnn (TST.PrdCnsType pol) where 
   prettyAnn pctype = prettyAnn (embedTST pctype)
@@ -99,7 +99,7 @@ instance PrettyAnn CST.PrdCnsTyp where
   prettyAnn (CST.CnsType ty) = returnKw <+> prettyAnn ty
 
 instance {-# OVERLAPPING #-} PrettyAnn (RST.LinearContext pol) where
-  prettyAnn ctxt = prettyAnn (unresolve ctxt)
+  prettyAnn ctxt = prettyAnn (runUnresolveM (unresolve ctxt))
 
 instance {-# OVERLAPPING #-} PrettyAnn CST.LinearContext where
   prettyAnn ctxt = parens' comma (prettyAnn <$> ctxt)
@@ -108,7 +108,7 @@ instance {-# OVERLAPPING #-} PrettyAnn (TST.LinearContext pol) where
   prettyAnn ctxt = parens' comma (prettyAnn <$> ctxt)
 
 instance PrettyAnn (RST.XtorSig pol) where
-  prettyAnn xtorSig = prettyAnn (unresolve xtorSig)
+  prettyAnn xtorSig = prettyAnn (runUnresolveM (unresolve xtorSig))
 
 instance PrettyAnn (TST.XtorSig pol) where
   prettyAnn xtorSig = prettyAnn (embedTST xtorSig)
@@ -121,7 +121,7 @@ instance PrettyAnn CST.XtorSig where
 ---------------------------------------------------------------------------------
 
 instance PrettyAnn (RST.Typ pol) where
-  prettyAnn typ = prettyAnn (unresolve typ)
+  prettyAnn typ = prettyAnn (runUnresolveM (unresolve typ))
 
 instance PrettyAnn (TST.Typ pol) where
   prettyAnn typ = prettyAnn (embedTST typ)
@@ -169,7 +169,7 @@ instance PrettyAnn CST.Typ where
 ---------------------------------------------------------------------------------
 
 instance PrettyAnn (RST.TypeScheme pol) where
-  prettyAnn tys = prettyAnn (unresolve tys)
+  prettyAnn tys = prettyAnn (runUnresolveM (unresolve tys))
 
 instance PrettyAnn (TST.TypeScheme pol) where
   prettyAnn tys = prettyAnn (embedTST tys)

--- a/src/Resolution/Unresolve.hs
+++ b/src/Resolution/Unresolve.hs
@@ -25,9 +25,12 @@ newtype UnresolveM a =
   MkUnresolveM { unUnresolveM :: State ([FreeVarName],[FreeVarName]) a }
     deriving (Functor, Applicative,Monad, MonadState ([FreeVarName],[FreeVarName]))
 
-names :: ([FreeVarName], [FreeVarName])
-names =  ((\y -> MkFreeVarName ("x" <> T.pack (show y))) <$> [(1 :: Int)..]
-         ,(\y -> MkFreeVarName ("k" <> T.pack (show y))) <$> [(1 :: Int)..])
+runUnresolveM :: UnresolveM a -> a
+runUnresolveM m = evalState (unUnresolveM m) names
+  where
+    names :: ([FreeVarName], [FreeVarName])
+    names =  ((\y -> MkFreeVarName ("x" <> T.pack (show y))) <$> [(1 :: Int)..]
+             ,(\y -> MkFreeVarName ("k" <> T.pack (show y))) <$> [(1 :: Int)..])
 
 fresh :: PrdCns -> UnresolveM FreeVarName
 fresh Prd = do
@@ -211,8 +214,7 @@ instance EmbedRST RST.CmdCase CST.TermCase where
 
 instance Unresolve RST.CmdCase CST.TermCase where
   unresolve :: RST.CmdCase -> CST.TermCase
-  unresolve cmdcase =
-    embedRST (evalState (unUnresolveM (createNames cmdcase)) names)
+  unresolve cmdcase = embedRST (runUnresolveM (createNames cmdcase))
 
 -- TermCase
 
@@ -240,8 +242,7 @@ instance EmbedRST (RST.TermCase pc) CST.TermCase where
 
 instance Unresolve (RST.TermCase pc) CST.TermCase where
   unresolve :: RST.TermCase pc -> CST.TermCase
-  unresolve termcase =
-    embedRST (evalState (unUnresolveM (createNames termcase)) names)
+  unresolve termcase = embedRST (runUnresolveM (createNames termcase))
 
 -- TermCaseI
 
@@ -270,8 +271,7 @@ instance EmbedRST (RST.TermCaseI pc) CST.TermCase where
 
 instance Unresolve (RST.TermCaseI pc) CST.TermCase where
   unresolve :: RST.TermCaseI pc -> CST.TermCase
-  unresolve termcasei =
-    embedRST (evalState (unUnresolveM (createNames termcasei)) names)
+  unresolve termcasei = embedRST (runUnresolveM (createNames termcasei))
 
 -- InstanceCase
 
@@ -300,8 +300,7 @@ instance EmbedRST RST.InstanceCase CST.TermCase where
 
 instance Unresolve RST.InstanceCase CST.TermCase where
   unresolve :: RST.InstanceCase -> CST.TermCase
-  unresolve instancecase =
-    embedRST (open (evalState (unUnresolveM (createNames instancecase)) names))
+  unresolve instancecase = embedRST (open (runUnresolveM (createNames instancecase)))
 
 -- Term
 
@@ -455,7 +454,7 @@ instance EmbedRST (RST.Term pc) CST.Term where
 
 instance Unresolve (RST.Term pc) CST.Term where
   unresolve :: RST.Term pc -> CST.Term
-  unresolve tm = embedRST (open (evalState (unUnresolveM (createNames tm)) names))
+  unresolve tm = embedRST (open (runUnresolveM (createNames tm)))
 
 -- Command
 
@@ -557,8 +556,7 @@ instance EmbedRST RST.Command CST.Term where
 
 instance Unresolve RST.Command CST.Term where
   unresolve :: RST.Command -> CST.Term
-  unresolve cmd =
-    embedRST (open (evalState (unUnresolveM (createNames cmd)) names))
+  unresolve cmd = embedRST (open (runUnresolveM (createNames cmd)))
 
 ---------------------------------------------------------------------------------
 -- Unresolving types

--- a/test/Spec/Focusing.hs
+++ b/test/Spec/Focusing.hs
@@ -30,7 +30,7 @@ testHelper (example,decls) cbx = describe (show cbx ++ " Focusing the program in
       case decls of
         Left err -> it "Could not read in example " $ expectationFailure (ppPrintString err)
         Right decls -> do
-          let focusedDecls :: CST.Module = unresolve $ embedCore $ embedTST $ focus cbx decls
+          let focusedDecls :: CST.Module = runUnresolveM $ unresolve $ embedCore $ embedTST $ focus cbx decls
           res <- runIO $ inferProgramIO defaultDriverState focusedDecls
           case res of
             (Left err,_) -> do


### PR DESCRIPTION
Merge `Open` and `createNames` in order to only traverse once.