### PR TITLE
Merge datatype elaboration

### DIFF
--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -150,67 +150,13 @@ resolveDataDecl CST.MkDataDecl { data_loc, data_doc, data_refined, data_name, da
           h :: ResolveReader -> ResolveReader
           h r = r { rr_modules = f $ rr_modules r }
       (xtorsPos, xtorsNeg) <- local h (resolveXtors data_xtors)
-      -- Compute the resolved typename
-      NominalResult rtn _ _ _ <- lookupTypeConstructor data_loc data_name
-      -- Compute the empty refinement of the data/codata type. E.g. < Nat | >
-      (emptyRefinementPos, emptyRefinementNeg) <- computeEmptyRefinementType data_polarity rtn
-      -- Compute the full refinement of the data/codata type. E.g. mu a. < Nat | Z, S(a) >
-      (fullRefinementPos, fullRefinementNeg) <- computeFullRefinementType data_polarity rtn (xtorsPos, xtorsNeg)
-      -- Compute the refined xtor sigs
-      let xtorsRefinedPos = RST.replaceNominal emptyRefinementPos emptyRefinementNeg rtn <$> xtorsPos
-      -- The negative ones are called by `getXtorSigsUpper` which are used as upper bounds to Xtors!
-      let xtorsRefinedNeg = RST.replaceNominal fullRefinementPos fullRefinementNeg rtn <$> xtorsNeg
       pure RST.RefinementDecl { data_loc = data_loc
                               , data_doc = data_doc
                               , data_name = data_name'
                               , data_polarity = data_polarity
-                              , data_refinement_empty = (emptyRefinementPos, emptyRefinementNeg)
-                              , data_refinement_full = (fullRefinementPos, fullRefinementNeg)
                               , data_kind = polyKind
                               , data_xtors = (xtorsPos, xtorsNeg)
-                              , data_xtors_refined = (xtorsRefinedPos,xtorsRefinedNeg)
                               }
-
--- | Given the polarity (data/codata) and the name of a type, compute the empty refinement of that type.
--- Example:
---
---   computeEmptyRefinementType Data   Nat = < Nat | >
---   computeEmptyRefinementType Codata Foo = { Foo | }
--- 
-computeEmptyRefinementType :: CST.DataCodata
-                           -> RnTypeName
-                           -> ResolverM (RST.Typ Pos, RST.Typ Neg)
-computeEmptyRefinementType CST.Data   tn =
-  pure (RST.TyDataRefined   defaultLoc PosRep tn [], RST.TyDataRefined   defaultLoc NegRep tn [])
-computeEmptyRefinementType CST.Codata tn =
-  pure (RST.TyCodataRefined defaultLoc PosRep tn [], RST.TyCodataRefined defaultLoc NegRep tn [])
-
--- | Given the polarity (data/codata), the name and the constructors/destructors of a type, compute the
--- full refinement of that type.
--- Example:
---
---   computeFullRefinementType Data Nat [Z,S(Nat)] = mu a. < Nat | Z, S(a) >
---
-computeFullRefinementType :: CST.DataCodata
-                          -> RnTypeName
-                          -> ([RST.XtorSig Pos], [RST.XtorSig Neg])
-                          -> ResolverM (RST.Typ Pos, RST.Typ Neg)
-computeFullRefinementType dc tn (xtorsPos, xtorsNeg) = do
-  -- Define the variable that stands for the recursive occurrences in the translation.
-  let recVar = MkRecTVar "α"
-  let recVarPos = RST.TyRecVar defaultLoc PosRep recVar
-  let recVarNeg = RST.TyRecVar defaultLoc NegRep recVar
-  -- Replace all the recursive occurrences of the type by the variable "α" in the constructors/destructors.
-  let xtorsReplacedPos :: [RST.XtorSig Pos] = RST.replaceNominal recVarPos recVarNeg tn <$> xtorsPos
-  let xtorsReplacedNeg :: [RST.XtorSig Neg] = RST.replaceNominal recVarPos recVarNeg tn <$> xtorsNeg
-  -- Assemble the 
-  let fullRefinementTypePos :: RST.Typ Pos = case dc of
-                   CST.Data   -> RST.TyRec defaultLoc PosRep recVar (RST.TyDataRefined   defaultLoc PosRep tn xtorsReplacedPos)
-                   CST.Codata -> RST.TyRec defaultLoc PosRep recVar (RST.TyCodataRefined defaultLoc PosRep tn xtorsReplacedNeg)
-  let fullRefinementTypeNeg :: RST.Typ Neg = case dc of
-                   CST.Data   -> RST.TyRec defaultLoc NegRep recVar (RST.TyDataRefined defaultLoc NegRep tn   xtorsReplacedNeg)
-                   CST.Codata -> RST.TyRec defaultLoc NegRep recVar (RST.TyCodataRefined defaultLoc NegRep tn xtorsReplacedPos)
-  pure (fullRefinementTypePos, fullRefinementTypeNeg)
 
 ---------------------------------------------------------------------------------
 -- Producer / Consumer Declarations

--- a/src/Syntax/RST/Program.hs
+++ b/src/Syntax/RST/Program.hs
@@ -212,18 +212,11 @@ data DataDecl =
     -- ^ The name of the type. E.g. "List".
   , data_polarity :: DataCodata
     -- ^ Whether a data or codata type is declared.
-  , data_refinement_empty :: (Typ Pos, Typ Neg)
-    -- ^ The lower bound of the refinement type. E.g. `< Nat | >`
-  , data_refinement_full :: (Typ Pos, Typ Neg)
-    -- ^ The upper bound of the refinement type. E.g. `mu alpha. < Nat | Z, S(alpha) >`
   , data_kind :: PolyKind
     -- ^ The kind of the type constructor.
   , data_xtors :: ([XtorSig Pos], [XtorSig Neg])
     -- ^ The constructors/destructors of the declaration,
     -- as written by the user.
-  , data_xtors_refined :: ([XtorSig Pos], [XtorSig Neg])
-    -- ^ The constructors/destructors of the declaration,
-    -- with recursive occurrences replaced by the refinement type.
   }
 
 deriving instance Show DataDecl

--- a/src/Translate/EmbedTST.hs
+++ b/src/Translate/EmbedTST.hs
@@ -223,20 +223,14 @@ instance EmbedTST TST.DataDecl RST.DataDecl where
                               , data_doc = doc
                               , data_name = tyn
                               , data_polarity = pol
-                              , data_refinement_empty = empt
-                              , data_refinement_full = ful
                               , data_kind = polyknd
-                              , data_xtors = xtors
-                              , data_xtors_refined = xtors' } =
+                              , data_xtors = xtors } =
     RST.RefinementDecl { data_loc = loc
                        , data_doc = doc
                        , data_name = tyn
                        , data_polarity = pol
-                       , data_refinement_empty = BF.bimap embedTST embedTST empt
-                       , data_refinement_full = BF.bimap embedTST embedTST ful
                        , data_kind = polyknd
                        , data_xtors = BF.bimap (map embedTST) (map embedTST) xtors
-                       , data_xtors_refined = BF.bimap (map embedTST) (map embedTST) xtors'
                        }
 
 instance EmbedTST TST.Declaration Core.Declaration where

--- a/src/TypeInference/GenerateConstraints/Kinds.hs
+++ b/src/TypeInference/GenerateConstraints/Kinds.hs
@@ -25,6 +25,8 @@ import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Foldable (find)
 import Data.Bifunctor (bimap)
+import qualified Syntax.CST.Types as CST
+import Syntax.RST.Types (Polarity(..), PolarityRep (..))
 
 --------------------------------------------------------------------------------------------
 -- Helpers
@@ -260,6 +262,47 @@ annotTy (RST.TyFlipPol pol ty) = do
   return $ TST.TyFlipPol pol ty'
 
 
+-- | Given the polarity (data/codata) and the name of a type, compute the empty refinement of that type.
+-- Example:
+--
+--   computeEmptyRefinementType Data   Nat = < Nat | >
+--   computeEmptyRefinementType Codata Foo = { Foo | }
+-- 
+computeEmptyRefinementType :: CST.DataCodata
+                           -> RnTypeName
+                           -> DataDeclM (RST.Typ Pos, RST.Typ Neg)
+computeEmptyRefinementType CST.Data   tn =
+  pure (RST.TyDataRefined   defaultLoc PosRep tn [], RST.TyDataRefined   defaultLoc NegRep tn [])
+computeEmptyRefinementType CST.Codata tn =
+  pure (RST.TyCodataRefined defaultLoc PosRep tn [], RST.TyCodataRefined defaultLoc NegRep tn [])
+
+-- | Given the polarity (data/codata), the name and the constructors/destructors of a type, compute the
+-- full refinement of that type.
+-- Example:
+--
+--   computeFullRefinementType Data Nat [Z,S(Nat)] = mu a. < Nat | Z, S(a) >
+--
+computeFullRefinementType :: CST.DataCodata
+                          -> RnTypeName
+                          -> ([RST.XtorSig Pos], [RST.XtorSig Neg])
+                          -> DataDeclM (RST.Typ Pos, RST.Typ Neg)
+computeFullRefinementType dc tn (xtorsPos, xtorsNeg) = do
+  -- Define the variable that stands for the recursive occurrences in the translation.
+  let recVar = MkRecTVar "α"
+  let recVarPos = RST.TyRecVar defaultLoc PosRep recVar
+  let recVarNeg = RST.TyRecVar defaultLoc NegRep recVar
+  -- Replace all the recursive occurrences of the type by the variable "α" in the constructors/destructors.
+  let xtorsReplacedPos :: [RST.XtorSig Pos] = RST.replaceNominal recVarPos recVarNeg tn <$> xtorsPos
+  let xtorsReplacedNeg :: [RST.XtorSig Neg] = RST.replaceNominal recVarPos recVarNeg tn <$> xtorsNeg
+  -- Assemble the 
+  let fullRefinementTypePos :: RST.Typ Pos = case dc of
+                   CST.Data   -> RST.TyRec defaultLoc PosRep recVar (RST.TyDataRefined   defaultLoc PosRep tn xtorsReplacedPos)
+                   CST.Codata -> RST.TyRec defaultLoc PosRep recVar (RST.TyCodataRefined defaultLoc PosRep tn xtorsReplacedNeg)
+  let fullRefinementTypeNeg :: RST.Typ Neg = case dc of
+                   CST.Data   -> RST.TyRec defaultLoc NegRep recVar (RST.TyDataRefined defaultLoc NegRep tn   xtorsReplacedNeg)
+                   CST.Codata -> RST.TyRec defaultLoc NegRep recVar (RST.TyCodataRefined defaultLoc NegRep tn xtorsReplacedPos)
+  pure (fullRefinementTypePos, fullRefinementTypeNeg)
+
 annotateDataDecl :: RST.DataDecl -> DataDeclM TST.DataDecl 
 annotateDataDecl RST.NominalDecl {
   data_loc = loc, 
@@ -268,7 +311,7 @@ annotateDataDecl RST.NominalDecl {
   data_polarity = pol,
   data_kind = polyknd,
   data_xtors = (xtorsPos, xtorsNeg)
-  } =do 
+  } = do 
     xtorsPos' <- mapM annotXtor xtorsPos
     xtorsNeg' <- mapM annotXtor xtorsNeg
     return TST.NominalDecl { 
@@ -284,28 +327,33 @@ annotateDataDecl RST.RefinementDecl {
   data_doc = doc,
   data_name = tyn,
   data_polarity = pol ,
-  data_refinement_empty = empt,
-  data_refinement_full = ful,
   data_kind = polyknd,
-  data_xtors = xtors,
-  data_xtors_refined = xtorsref
+  data_xtors = xtors
   } = do
+    -- Compute the full and empty refinement types:
+    (emptyPos, emptyNeg) <- computeEmptyRefinementType pol tyn
+    emptPos' <- annotTy emptyPos
+    emptNeg' <- annotTy emptyNeg
+    (fulPos, fulNeg) <- computeFullRefinementType pol tyn xtors
+    fulPos' <- annotTy fulPos
+    fulNeg' <- annotTy fulNeg
+    -- Compute the annotated xtors (without refinement)
     xtorsPos <- mapM annotXtor (fst xtors)
     xtorsNeg <- mapM annotXtor (snd xtors)
     addXtors (xtorsPos,xtorsNeg)
-    xtorsRefPos <- mapM annotXtor (fst xtorsref)
-    xtorsRefNeg <- mapM annotXtor (snd xtorsref)
-    emptPos <- annotTy (fst empt)
-    emptNeg <- annotTy (snd empt)
-    fulPos <- annotTy (fst ful) 
-    fulNeg <- annotTy (snd ful)
+    -- Compute the refined xtors:
+    let xtorsRefinedPos = RST.replaceNominal emptyPos emptyNeg tyn <$> (fst xtors)
+    -- The negative ones are called by `getXtorSigsUpper` which are used as upper bounds to Xtors!
+    let xtorsRefinedNeg = RST.replaceNominal fulPos fulNeg tyn <$> (snd xtors)
+    xtorsRefPos <- mapM annotXtor xtorsRefinedPos
+    xtorsRefNeg <- mapM annotXtor xtorsRefinedNeg
     return TST.RefinementDecl {
       data_loc = loc,
       data_doc = doc,
       data_name = tyn,
       data_polarity = pol ,
-      data_refinement_empty = (emptPos, emptNeg), 
-      data_refinement_full = (fulPos, fulNeg), 
+      data_refinement_empty = (emptPos', emptNeg'), 
+      data_refinement_full = (fulPos', fulNeg'), 
       data_kind = polyknd,
       data_xtors = (xtorsPos, xtorsNeg),
       data_xtors_refined = (xtorsRefPos, xtorsRefNeg) 


### PR DESCRIPTION
We previously had two places where we elaborated a user-written data declaration:

- In `src/Resolution/Program.hs` we computed the refinement types and the Xtor signatures where we replace occurrences of the nominal type by the refinement type.
- In `src/TypeInference/GenerateConstraints/Kinds.hs` we annotate the xtor sigs with the correct kind.

In this PR we just merge them so that the entire logic of datatype elaboration lives in `src/TypeInference/GenerateConstraints/Kinds.hs`. This allows for some further cleanup, but this can be done in separate PRs.