### PR TITLE
Refactor LSP server

### DIFF
--- a/app/LSP/Definition.hs
+++ b/app/LSP/Definition.hs
@@ -1,43 +1,111 @@
 module LSP.Definition where
 
-import Control.Monad.IO.Class ( MonadIO)
-import Control.Monad.IO.Unlift (MonadUnliftIO)
-
-import Data.Map (Map)
-import Data.IORef
-import Language.LSP.Server
-import Language.LSP.Types
-import Data.Text qualified as T
-import qualified Data.List.NonEmpty as NE
-import Errors (Error)
 import Control.Monad.Except (runExcept)
+import Control.Monad.IO.Class ( MonadIO(..) )
+import Control.Monad.IO.Unlift (MonadUnliftIO)
+import Data.IORef ( IORef )
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as M
+import Data.Maybe ( fromMaybe )
+import Data.SortedList qualified as SL
+import Data.Text qualified as T
+import Language.LSP.Server qualified as LSP
+import Language.LSP.Types qualified as LSP
+import Language.LSP.VFS ( virtualFileText )
+
+import Driver.Definition ( defaultDriverState )
+import Driver.Driver ( inferProgramIO )
+import Errors ( Warning, Error )
+import Loc ( getLoc )
+import LSP.MegaparsecToLSP ( locToRange )
 import Parser.Definition (runFileParser)
-import Parser.Parser (moduleP)
-import qualified Syntax.CST.Program as CST
-import Syntax.CST.Program (adjustModulePath)
+import Parser.Program ( moduleP )
+import Pretty.Pretty ( ppPrint )
+import Syntax.CST.Program qualified as CST
 
 ---------------------------------------------------------------------------------
 -- LSPMonad and Utility Functions
 ---------------------------------------------------------------------------------
 
-type HoverMap   = Map Range Hover
-type HoverCache = Map Uri HoverMap
-newtype LSPConfig = MkLSPConfig (IORef HoverCache)
+newtype LSPConfig = MkLSPConfig (IORef ())
 
-newtype LSPMonad a = MkLSPMonad { unLSPMonad :: LspT LSPConfig IO a }
-  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, MonadLsp LSPConfig)
+newtype LSPMonad a = MkLSPMonad { unLSPMonad :: LSP.LspT LSPConfig IO a }
+  deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, LSP.MonadLsp LSPConfig)
 
 sendInfo :: T.Text -> LSPMonad ()
-sendInfo msg = sendNotification SWindowShowMessage (ShowMessageParams MtInfo msg)
+sendInfo msg = LSP.sendNotification LSP.SWindowShowMessage (LSP.ShowMessageParams LSP.MtInfo msg)
 
 sendWarning :: T.Text -> LSPMonad ()
-sendWarning msg = sendNotification SWindowShowMessage (ShowMessageParams MtWarning  msg)
+sendWarning msg = LSP.sendNotification LSP.SWindowShowMessage (LSP.ShowMessageParams LSP.MtWarning  msg)
 
 sendError :: T.Text -> LSPMonad ()
-sendError msg = sendNotification SWindowShowMessage (ShowMessageParams MtError msg)
+sendError msg = LSP.sendNotification LSP.SWindowShowMessage (LSP.ShowMessageParams LSP.MtError msg)
 
 getModuleFromFilePath :: FilePath -> T.Text -> Either (NE.NonEmpty Error) CST.Module
 getModuleFromFilePath fp file = do
   mod <- runExcept (runFileParser fp (moduleP fp) file)
-  adjustModulePath mod fp
+  CST.adjustModulePath mod fp
 
+---------------------------------------------------------------------------------------------
+-- Publishing Diagnostics
+---------------------------------------------------------------------------------------------
+
+class IsDiagnostic a where
+  toDiagnostic :: a -> [LSP.Diagnostic]
+
+instance IsDiagnostic Warning where
+  toDiagnostic :: Warning -> [LSP.Diagnostic]
+  toDiagnostic warn = [diag]
+    where
+      diag = LSP.Diagnostic { _range = locToRange (getLoc warn)
+                            , _severity = Just LSP.DsWarning
+                            , _code = Nothing
+                            , _source = Nothing
+                            , _message = ppPrint warn
+                            , _tags = Nothing
+                            , _relatedInformation = Nothing
+                            }
+
+instance IsDiagnostic Error where
+  toDiagnostic :: Error -> [LSP.Diagnostic]
+  toDiagnostic err = [diag]
+    where
+      diag = LSP.Diagnostic { _range = locToRange (getLoc err)
+                            , _severity = Just LSP.DsError
+                            , _code = Nothing
+                            , _source = Nothing
+                            , _message = ppPrint err
+                            , _tags = Nothing
+                            , _relatedInformation = Nothing
+                            }
+
+sendDiagnostics :: IsDiagnostic a => LSP.NormalizedUri -> [a] -> LSPMonad ()
+sendDiagnostics uri w = do
+  let diags = concatMap toDiagnostic w
+  LSP.publishDiagnostics 42 uri Nothing (M.fromList [(Just "Duo", SL.toSortedList diags)])
+
+---------------------------------------------------------------------------------------------
+-- Main loop
+---------------------------------------------------------------------------------------------
+
+publishErrors :: LSP.Uri -> LSPMonad ()
+publishErrors uri = do
+  LSP.flushDiagnosticsBySource 42 (Just "TypeInference")
+  mfile <- LSP.getVirtualFile (LSP.toNormalizedUri uri)
+  case mfile of
+    Nothing -> sendError "Virtual File not present!"
+    Just vfile -> do
+      let file = virtualFileText vfile
+      let fp = fromMaybe "fail" (LSP.uriToFilePath uri)
+      let decls = getModuleFromFilePath fp file
+      case decls of
+        Left errs -> do
+          sendDiagnostics (LSP.toNormalizedUri uri) (NE.toList errs)
+        Right decls -> do
+          (res, warnings) <- liftIO $ inferProgramIO defaultDriverState decls
+          sendDiagnostics (LSP.toNormalizedUri uri) warnings
+          case res of
+            Left errs -> do
+              sendDiagnostics (LSP.toNormalizedUri uri) (NE.toList errs)
+            Right (_,_) -> do
+              pure ()

--- a/app/LSP/Definition.hs
+++ b/app/LSP/Definition.hs
@@ -5,6 +5,7 @@ import Control.Monad.IO.Class ( MonadIO(..) )
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.IORef ( IORef )
 import Data.List.NonEmpty qualified as NE
+import Data.Map ( Map )
 import Data.Map qualified as M
 import Data.Maybe ( fromMaybe )
 import Data.SortedList qualified as SL
@@ -22,12 +23,14 @@ import Parser.Definition (runFileParser)
 import Parser.Program ( moduleP )
 import Pretty.Pretty ( ppPrint )
 import Syntax.CST.Program qualified as CST
+import Syntax.TST.Program qualified as TST
 
 ---------------------------------------------------------------------------------
 -- LSPMonad and Utility Functions
 ---------------------------------------------------------------------------------
 
-newtype LSPConfig = MkLSPConfig (IORef ())
+
+newtype LSPConfig = MkLSPConfig { tst_map :: IORef (Map LSP.Uri TST.Module) }
 
 newtype LSPMonad a = MkLSPMonad { unLSPMonad :: LSP.LspT LSPConfig IO a }
   deriving newtype (Functor, Applicative, Monad, MonadIO, MonadUnliftIO, LSP.MonadLsp LSPConfig)

--- a/app/LSP/Handler/JumpToDef.hs
+++ b/app/LSP/Handler/JumpToDef.hs
@@ -3,7 +3,6 @@ module LSP.Handler.JumpToDef ( jumpToDefHandler ) where
 import Control.Monad.IO.Class ( MonadIO(liftIO) )
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Maybe ( fromMaybe )
 import Data.Text qualified as T
 import Language.LSP.Types
     ( Uri(Uri),
@@ -12,21 +11,16 @@ import Language.LSP.Types
       RequestMessage(RequestMessage),
       ResponseError(..),
       TextDocumentIdentifier(TextDocumentIdentifier),
-      toNormalizedUri,
       type (|?)(InL),
-      uriToFilePath,
       DefinitionParams(DefinitionParams),
       Location(..),
       Position,
       ErrorCode(InvalidRequest) )
 import Language.LSP.Server
-    ( getVirtualFile, requestHandler, Handlers )
-import Language.LSP.VFS ( VirtualFile, virtualFileText )
+    (  requestHandler, Handlers, getConfig )
 import System.Log.Logger ( debugM )
 
-import Driver.Definition ( defaultDriverState )
-import Driver.Driver ( inferProgramIO )
-import LSP.Definition ( LSPMonad, getModuleFromFilePath )
+import LSP.Definition ( LSPMonad, LSPConfig (..), sendInfo )
 import LSP.MegaparsecToLSP ( locToRange, lookupInRangeMap )
 import Sugar.Desugar (Desugar(..))
 import Syntax.RST.Terms qualified as RST
@@ -34,27 +28,19 @@ import Syntax.CST.Names
 import Syntax.RST.Types qualified as RST
 import Syntax.RST.Program qualified as RST
 import Translate.EmbedTST(EmbedTST(..))
+import Data.IORef (readIORef)
 
 jumpToDefHandler :: Handlers LSPMonad
 jumpToDefHandler = requestHandler STextDocumentDefinition $ \req responder -> do
     let (RequestMessage _ _ _ (DefinitionParams (TextDocumentIdentifier uri) pos _ _)) = req
     liftIO $ debugM "lspserver.JumpToDefHandler" ("Received definition request: " <> show uri <> " at: " <> show pos)
-    mfile <- getVirtualFile (toNormalizedUri uri)
-    let vfile :: VirtualFile = fromMaybe (error "Virtual File not present!") mfile
-    let file = virtualFileText vfile
-    let fp = fromMaybe "fail" (uriToFilePath uri)
-    let decls = getModuleFromFilePath fp file
-    case decls of
-      Left _err -> do
+    MkLSPConfig ref <- getConfig
+    cache <- liftIO $ readIORef ref
+    case M.lookup uri cache of
+      Nothing -> do
+        sendInfo ("Cache not initialized for: " <> T.pack (show uri))
         responder (Left (ResponseError { _code = InvalidRequest, _message = "", _xdata = Nothing}))
-      Right decls -> do
-        (res, _warnings) <- liftIO $ inferProgramIO defaultDriverState decls
-        case res of
-          Left _err -> do
-            responder (Left (ResponseError { _code = InvalidRequest, _message = "", _xdata = Nothing}))
-          Right (_,prog) -> do
-            responder (generateJumpToDef pos (embedCore (embedTST prog)))
-
+      Just mod -> responder (generateJumpToDef pos (embedCore (embedTST mod)))
 
 generateJumpToDef :: Position -> RST.Module -> Either ResponseError (Location |? b)
 generateJumpToDef pos prog = do

--- a/app/LSP/Handler/Various.hs
+++ b/app/LSP/Handler/Various.hs
@@ -1,0 +1,137 @@
+module LSP.Handler.Various
+  ( initializedHandler
+  , exitHandler
+  , shutdownHandler
+  , cancelRequestHandler
+  , didOpenHandler
+  , didChangeHandler
+  , didCloseHandler
+  ) where
+
+import Control.Monad.IO.Class ( liftIO )
+import Language.LSP.Types qualified as LSP
+import Language.LSP.Server qualified as LSP
+import System.Exit ( exitSuccess ) 
+import System.Log.Logger ( debugM )
+
+import LSP.Definition ( LSPMonad, publishErrors )
+
+---------------------------------------------------------------------------------
+-- Initialized Notification Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized
+--
+-- The initialized notification is sent from the client to the server after the
+-- client received the result of the initialize request but before the client is
+-- sending any other request or notification to the server. 
+---------------------------------------------------------------------------------
+
+initializedHandler :: LSP.Handlers LSPMonad
+initializedHandler = LSP.notificationHandler LSP.SInitialized $ \_notif -> do
+  liftIO $ debugM "lspserver" "LSP Server Initialized"
+
+---------------------------------------------------------------------------------
+-- Exit Notification Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#exit
+--
+-- A notification to ask the server to exit its process. The server should exit
+-- with success code 0 if the shutdown request has been received before;
+-- otherwise with error code 1.
+---------------------------------------------------------------------------------
+
+exitHandler :: LSP.Handlers LSPMonad
+exitHandler = LSP.notificationHandler LSP.SExit $ \_notif -> do
+  liftIO $ debugM "lspserver.exitHandler" "Received exit notification"
+  liftIO exitSuccess
+
+---------------------------------------------------------------------------------
+-- Shutdown Request Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown
+--
+-- The shutdown request is sent from the client to the server. It asks the server
+-- to shut down, but to not exit (otherwise the response might not be delivered
+-- correctly to the client). There is a separate exit notification that asks the
+-- server to exit. Clients must not send any notifications other than exit or
+-- requests to a server to which they have sent a shutdown request. Clients
+-- should also wait with sending the exit notification until they have received
+-- a response from the shutdown request.
+---------------------------------------------------------------------------------
+
+shutdownHandler :: LSP.Handlers LSPMonad
+shutdownHandler = LSP.requestHandler LSP.SShutdown $ \_re responder -> do
+  liftIO $ debugM "lspserver.shutdownHandler" "Received shutdown request"
+  responder (Right LSP.Empty)
+  liftIO exitSuccess
+
+---------------------------------------------------------------------------------
+-- Cancel Request Notification Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest
+--
+---------------------------------------------------------------------------------
+
+cancelRequestHandler :: LSP.Handlers LSPMonad
+cancelRequestHandler = LSP.notificationHandler LSP.SCancelRequest $ \_notif -> do
+  liftIO $ debugM "lspserver.cancelRequestHandler" "Received cancel request"
+  return ()
+
+---------------------------------------------------------------------------------
+-- DidOpenTextDocument Notification Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
+--
+-- The document open notification is sent from the client to the server to signal
+-- newly opened text documents. The document’s content is now managed by the
+-- client and the server must not try to read the document’s content using the
+-- document’s Uri. Open in this sense means it is managed by the client. It
+-- doesn’t necessarily mean that its content is presented in an editor. An open
+-- notification must not be sent more than once without a corresponding close
+-- notification send before. This means open and close notification must be
+-- balanced and the max open count for a particular textDocument is one. Note
+-- that a server’s ability to fulfill requests is independent of whether a text
+-- document is open or closed.
+---------------------------------------------------------------------------------
+
+didOpenHandler :: LSP.Handlers LSPMonad
+didOpenHandler = LSP.notificationHandler LSP.STextDocumentDidOpen $ \notif -> do
+  let (LSP.NotificationMessage _ _ (LSP.DidOpenTextDocumentParams (LSP.TextDocumentItem uri _ _ _))) = notif
+  liftIO $ debugM "lspserver.didOpenHandler" ("Opened file: " <> show uri)
+  publishErrors uri
+
+---------------------------------------------------------------------------------
+-- DidChangeTextDocument Notification Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange
+--
+-- he document change notification is sent from the client to the server to signal
+-- changes to a text document. Before a client can change a text document it must
+-- claim ownership of its content using the textDocument/didOpen notification. 
+---------------------------------------------------------------------------------
+
+didChangeHandler :: LSP.Handlers LSPMonad
+didChangeHandler = LSP.notificationHandler LSP.STextDocumentDidChange $ \notif -> do
+  let (LSP.NotificationMessage _ _ (LSP.DidChangeTextDocumentParams (LSP.VersionedTextDocumentIdentifier uri _) _)) = notif
+  liftIO $ debugM "lspserver.didChangeHandler" ("Changed file: " <> show uri)
+  publishErrors uri
+
+---------------------------------------------------------------------------------
+-- DidCloseTextDocument Notification Handler
+--
+-- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didClose
+--
+-- The document close notification is sent from the client to the server when the
+-- document got closed in the client. The document’s master now exists where the
+-- document’s Uri points to (e.g. if the document’s Uri is a file Uri the master
+-- now exists on disk). As with the open notification the close notification is
+-- about managing the document’s content. Receiving a close notification doesn’t
+-- mean that the document was open in an editor before. A close notification
+-- requires a previous open notification to be sent. Note that a server’s ability
+-- to fulfill requests is independent of whether a text document is open or closed.
+---------------------------------------------------------------------------------
+
+didCloseHandler :: LSP.Handlers LSPMonad
+didCloseHandler = LSP.notificationHandler LSP.STextDocumentDidClose $ \notif -> do
+  let (LSP.NotificationMessage _ _ (LSP.DidCloseTextDocumentParams uri)) = notif
+  liftIO $ debugM "lspserver.didCloseHandler" ("Closed file: " <> show uri)

--- a/app/LSP/LSP.hs
+++ b/app/LSP/LSP.hs
@@ -2,6 +2,7 @@ module LSP.LSP ( runLSP ) where
 
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef ( newIORef )
+import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Version (showVersion)
 import Language.LSP.Server qualified as LSP
@@ -54,7 +55,7 @@ serverOptions = LSP.Options
 
 definition :: IO (LSP.ServerDefinition LSPConfig)
 definition = do
-  initialCache <- newIORef ()
+  initialCache <- newIORef M.empty
   return LSP.ServerDefinition
     { defaultConfig = MkLSPConfig initialCache
     , onConfigurationChange = \config _ -> pure config

--- a/duo-lang.cabal
+++ b/duo-lang.cabal
@@ -201,6 +201,7 @@ executable duo
       LSP.Handler.Completion
       LSP.Handler.Hover
       LSP.Handler.JumpToDef
+      LSP.Handler.Various
       LSP.LSP
       LSP.MegaparsecToLSP
       Options


### PR DESCRIPTION
Refactor of the architecture of the LSP Server. Previously we used a cache which contained a HoverMap, and only the Hovers were cached. CodeActions and JumpToDefinition requests always triggered a recompilation of the entire module. The cache now consists of a Map from URI to TST.Module, which is then used by all the Handlers. This makes CodeActions much snappier.