### PR TITLE
Refactor patterns (2/n)

### DIFF
--- a/src/Dualize/Dualize.hs
+++ b/src/Dualize/Dualize.hs
@@ -12,6 +12,7 @@ import Syntax.CST.Types (PrdCnsRep(..), PrdCns(..))
 import Syntax.RST.Terms (PrimitiveOp)
 import Syntax.RST.Types (FlipPol, FlipPrdCns, PolarityRep(..), flipPolarityRep, flipPrdCns)
 import Syntax.RST.Program (PrdCnsToPol)
+import Syntax.Core.Terms (Pattern(..))
 import Syntax.TST.Types qualified as TST
 import Syntax.TST.Program qualified as TST
 import Syntax.TST.Terms

--- a/src/Eval/Definition.hs
+++ b/src/Eval/Definition.hs
@@ -14,6 +14,7 @@ import Pretty.Terms ()
 import Syntax.CST.Names
 import Syntax.CST.Kinds
 import Syntax.Core.Annot
+import Syntax.Core.Terms (Pattern(..))
 import Syntax.TST.Terms
 import Loc
 import Syntax.TST.Types qualified as TST

--- a/src/Eval/Eval.hs
+++ b/src/Eval/Eval.hs
@@ -14,6 +14,7 @@ import Pretty.Pretty
 import Syntax.CST.Kinds
 import Syntax.CST.Types (PrdCns(..), PrdCnsRep(..))
 import Syntax.Core.Annot
+import Syntax.Core.Terms (Pattern(..))
 import Syntax.TST.Terms
 import Eval.Definition
 import Eval.Primitives

--- a/src/Sugar/Core.hs
+++ b/src/Sugar/Core.hs
@@ -60,10 +60,10 @@ data TermCaseI (pc :: PrdCns) = MkTermCaseI
   , tmcasei_term :: Core.Term pc
   }
 resugarCmdCase :: PrdCnsRep pc -> Core.CmdCase -> TermCaseI pc
-resugarCmdCase PrdRep (Core.MkCmdCase loc (RST.XtorPat _ xt cases)
+resugarCmdCase PrdRep (Core.MkCmdCase loc (Core.XtorPat _ xt cases)
                 (Core.Apply _ (ApplyAnnotXCaseOfIInner i) t {-(BoundVar _ CnsRep (0,_))-} _)) =
                       MkTermCaseI loc (RST.XtorPatI loc xt (mySplitAt i cases)) t
-resugarCmdCase CnsRep (Core.MkCmdCase loc (RST.XtorPat _ xt cases)
+resugarCmdCase CnsRep (Core.MkCmdCase loc (Core.XtorPat _ xt cases)
                 (Core.Apply _ (ApplyAnnotXCaseOfIInner i) {-(BoundVar _ PrdRep (0,_))-} _ t)) =
                       MkTermCaseI loc (RST.XtorPatI loc xt (mySplitAt i cases)) t
 resugarCmdCase _ cmd = error $ "cannot resugar " ++ show cmd
@@ -83,14 +83,14 @@ pattern CaseOfI loc rep ns t cases <-
     CaseOfI loc PrdRep ns t cases =
      let
        desugarmatchCase (MkTermCaseI _ (RST.XtorPatI loc xt (as1, (), as2)) t) =
-         let pat = RST.XtorPat loc xt (as1 ++ [(Cns,Nothing)] ++ as2)  in
+         let pat = Core.XtorPat loc xt (as1 ++ [(Cns,Nothing)] ++ as2)  in
          Core.MkCmdCase loc pat $ Core.Apply loc (ApplyAnnotXCaseOfIInner $ length as1) t (BoundVar loc CnsRep (0,length as1))
      in
        Core.Apply loc ApplyAnnotCaseOfIOuter t (Core.XCase loc MatchAnnotCaseOfI CnsRep ns $ desugarmatchCase <$> cases)
     CaseOfI loc CnsRep ns t cases =
      let
        desugarmatchCase (MkTermCaseI _ (RST.XtorPatI loc xt (as1, (), as2)) t) =
-         let pat = RST.XtorPat loc xt (as1 ++ [(Prd,Nothing)] ++ as2)  in
+         let pat = Core.XtorPat loc xt (as1 ++ [(Prd,Nothing)] ++ as2)  in
          Core.MkCmdCase loc pat $ Core.Apply loc (ApplyAnnotXCaseOfIInner $ length as1)  (BoundVar loc PrdRep (0,length as1)) t
      in
        Core.Apply loc ApplyAnnotCaseOfIOuter t (Core.XCase loc MatchAnnotCaseOfI CnsRep ns $ desugarmatchCase <$> cases)
@@ -111,14 +111,14 @@ pattern CocaseOfI loc rep ns t cases <-
     CocaseOfI loc PrdRep ns t cases =
      let
        desugarcomatchCase (MkTermCaseI _ (RST.XtorPatI loc xt (as1, (), as2)) t) =
-         let pat = RST.XtorPat loc xt (as1 ++ [(Cns,Nothing)] ++ as2)  in
+         let pat = Core.XtorPat loc xt (as1 ++ [(Cns,Nothing)] ++ as2)  in
          Core.MkCmdCase loc pat $ Core.Apply loc (ApplyAnnotXCaseOfIInner $ length as1) t (BoundVar loc CnsRep (0,length as1))
      in
        Core.Apply loc ApplyAnnotCocaseOfIOuter (Core.XCase loc MatchAnnotCocaseOfI PrdRep ns $ desugarcomatchCase <$> cases) t
     CocaseOfI loc CnsRep ns t cases =
      let
        desugarcomatchCase (MkTermCaseI _ (RST.XtorPatI loc xt (as1, (), as2)) t) =
-         let pat = RST.XtorPat loc xt (as1 ++ [(Prd,Nothing)] ++ as2)  in
+         let pat = Core.XtorPat loc xt (as1 ++ [(Prd,Nothing)] ++ as2)  in
          Core.MkCmdCase loc pat $ Core.Apply loc (ApplyAnnotXCaseOfIInner $ length as1)  (BoundVar loc PrdRep (0,length as1)) t
      in
        Core.Apply loc ApplyAnnotCocaseOfIOuter (Core.XCase loc MatchAnnotCocaseOfI PrdRep ns $ desugarcomatchCase <$> cases) t
@@ -184,17 +184,17 @@ pattern Dtor loc rep ns xt t substi <-
 
 data TermCase (pc :: PrdCns) = MkTermCase
   { tmcase_loc  :: Loc
-  , tmcase_pat :: RST.Pattern
+  , tmcase_pat :: Core.Pattern
   , tmcase_term :: Core.Term pc
   }        
 
 resugarTermCase :: PrdCnsRep pc -> Core.CmdCase -> TermCase pc
-resugarTermCase PrdRep (Core.MkCmdCase loc (RST.XtorPat _ xt cases)
+resugarTermCase PrdRep (Core.MkCmdCase loc (Core.XtorPat _ xt cases)
                 (Core.Apply _ _ t {-(FreeVar _ CnsRep _)-} _ )) =
-                     MkTermCase loc (RST.XtorPat loc xt cases) t
-resugarTermCase CnsRep (Core.MkCmdCase loc (RST.XtorPat _ xt cases)
+                     MkTermCase loc (Core.XtorPat loc xt cases) t
+resugarTermCase CnsRep (Core.MkCmdCase loc (Core.XtorPat _ xt cases)
                 (Core.Apply _ _  {-(FreeVar _ PrdRep _)-} _ t)) =
-                     MkTermCase loc (RST.XtorPat loc xt cases) t    
+                     MkTermCase loc (Core.XtorPat loc xt cases) t    
 resugarTermCase _ cmd = error $ "compiler bug: resugarTermCase : cannot resugar " ++ show cmd                                  
 
 -- CaseOf:
@@ -244,10 +244,10 @@ pattern CocaseOf loc rep ns t cases <-
             Core.MuAbs loc MuAnnotCocaseOf CnsRep Nothing $ LN.close [(Prd, resVar)] $ LN.shift LN.ShiftUp cmd
 
 resugarCmdCase' :: PrdCnsRep pc -> Core.CmdCase -> TermCaseI pc
-resugarCmdCase' PrdRep (Core.MkCmdCase loc (RST.XtorPat _ xt cases)
+resugarCmdCase' PrdRep (Core.MkCmdCase loc (Core.XtorPat _ xt cases)
                 (Core.Apply _ (ApplyAnnotXCaseI i) t {-(BoundVar _ CnsRep (0,_))-} _ )) =
                       MkTermCaseI loc (RST.XtorPatI loc xt (mySplitAt i cases)) t
-resugarCmdCase' CnsRep (Core.MkCmdCase loc (RST.XtorPat _ xt cases)
+resugarCmdCase' CnsRep (Core.MkCmdCase loc (Core.XtorPat _ xt cases)
                 (Core.Apply _ (ApplyAnnotXCaseI i) {-(BoundVar _ PrdRep (0,_))-} _ t)) =
                       MkTermCaseI loc (RST.XtorPatI loc xt (mySplitAt i cases)) t
 resugarCmdCase' _ cmd = error $ "cannot resugar " ++ show cmd
@@ -267,14 +267,14 @@ pattern XCaseI loc rep rep' ns cases <- Core.XCase loc (MatchAnnotXCaseI rep) re
    XCaseI loc PrdRep rep' ns cases =    
     let
         desugarmatchCase (MkTermCaseI _ (RST.XtorPatI loc xt (as1, (), as2)) t) =
-          let pat = RST.XtorPat loc xt (as1 ++ [(Cns,Nothing)] ++ as2) in
+          let pat = Core.XtorPat loc xt (as1 ++ [(Cns,Nothing)] ++ as2) in
           Core.MkCmdCase loc pat $ Core.Apply loc (ApplyAnnotXCaseI $ length as1) t (BoundVar loc CnsRep (0,length as1))
     in
         Core.XCase loc (MatchAnnotXCaseI PrdRep) rep' ns $ desugarmatchCase <$> cases
    XCaseI loc CnsRep rep' ns cases =    
     let
         desugarmatchCase (MkTermCaseI _ (RST.XtorPatI loc xt (as1, (), as2)) t) =
-          let pat = RST.XtorPat loc xt (as1 ++ [(Prd,Nothing)] ++ as2) in
+          let pat = Core.XtorPat loc xt (as1 ++ [(Prd,Nothing)] ++ as2) in
           Core.MkCmdCase loc pat $ Core.Apply loc (ApplyAnnotXCaseI $ length as1) (BoundVar loc PrdRep (0,length as1)) t
     in
         Core.XCase loc (MatchAnnotXCaseI CnsRep) rep' ns $ desugarmatchCase <$> cases
@@ -285,15 +285,15 @@ pattern XCaseI loc rep rep' ns cases <- Core.XCase loc (MatchAnnotXCaseI rep) re
 
 
 extractCmdCase :: PrdCnsRep pc -> [Core.CmdCase] -> Maybe (FreeVarName,Core.Term pc) 
-extractCmdCase PrdRep [Core.MkCmdCase _ (RST.XtorPat _ (MkXtorName "Ap") [(Prd,Just fv),(Cns,Nothing)]) (Core.Apply _ ApplyAnnotLambda tm (Core.BoundVar _ CnsRep (0,1)))] = Just (fv,tm)
-extractCmdCase CnsRep [Core.MkCmdCase _ (RST.XtorPat _ (MkXtorName "CoAp") [(Cns,Just fv),(Prd,Nothing)]) (Core.Apply _ ApplyAnnotLambda  (Core.BoundVar _ PrdRep (0,1)) tm)] = Just (fv,tm)
+extractCmdCase PrdRep [Core.MkCmdCase _ (Core.XtorPat _ (MkXtorName "Ap") [(Prd,Just fv),(Cns,Nothing)]) (Core.Apply _ ApplyAnnotLambda tm (Core.BoundVar _ CnsRep (0,1)))] = Just (fv,tm)
+extractCmdCase CnsRep [Core.MkCmdCase _ (Core.XtorPat _ (MkXtorName "CoAp") [(Cns,Just fv),(Prd,Nothing)]) (Core.Apply _ ApplyAnnotLambda  (Core.BoundVar _ PrdRep (0,1)) tm)] = Just (fv,tm)
 extractCmdCase _ _ = Nothing 
 
 pattern Lambda  :: Loc ->  PrdCnsRep pc -> FreeVarName -> Core.Term pc  -> Core.Term pc 
 pattern Lambda loc pc fv tm <- Core.XCase loc MatchAnnotLambda pc CST.Nominal (extractCmdCase pc -> Just (fv,tm))
   where 
-    Lambda loc PrdRep x tm = Core.XCase loc MatchAnnotLambda PrdRep CST.Nominal [Core.MkCmdCase loc (RST.XtorPat loc (MkXtorName "Ap") [(Prd,Just x),(Cns,Nothing)]) (Core.Apply loc ApplyAnnotLambda tm (BoundVar loc CnsRep (0,1)))]  
-    Lambda loc CnsRep x tm = Core.XCase loc MatchAnnotLambda CnsRep CST.Nominal [Core.MkCmdCase loc (RST.XtorPat loc (MkXtorName "CoAp") [(Cns,Just x),(Prd,Nothing)]) (Core.Apply loc ApplyAnnotLambda (BoundVar loc PrdRep (0,1)) tm )]  
+    Lambda loc PrdRep x tm = Core.XCase loc MatchAnnotLambda PrdRep CST.Nominal [Core.MkCmdCase loc (Core.XtorPat loc (MkXtorName "Ap") [(Prd,Just x),(Cns,Nothing)]) (Core.Apply loc ApplyAnnotLambda tm (BoundVar loc CnsRep (0,1)))]  
+    Lambda loc CnsRep x tm = Core.XCase loc MatchAnnotLambda CnsRep CST.Nominal [Core.MkCmdCase loc (Core.XtorPat loc (MkXtorName "CoAp") [(Cns,Just x),(Prd,Nothing)]) (Core.Apply loc ApplyAnnotLambda (BoundVar loc PrdRep (0,1)) tm )]  
 
 pattern RawCase ::  Loc -> PrdCnsRep pc -> CST.NominalStructural -> [Core.CmdCase] -> Core.Term pc
 pattern RawCase loc pc ns cases = Core.XCase loc MatchAnnotOrig pc ns cases 

--- a/src/Sugar/Desugar.hs
+++ b/src/Sugar/Desugar.hs
@@ -29,12 +29,12 @@ class Desugar a b | a -> b, b -> a where
 -- Implementation of `Desugar` for patterns and cases
 ---------------------------------------------------------------------------------
 
-instance Desugar RST.Pattern RST.Pattern where
-  desugar :: RST.Pattern -> RST.Pattern
-  desugar (RST.XtorPat loc xt args) = RST.XtorPat loc xt args
+instance Desugar RST.Pattern Core.Pattern where
+  desugar :: RST.Pattern -> Core.Pattern
+  desugar (RST.XtorPat loc xt args) = Core.XtorPat loc xt args
 
-  embedCore :: RST.Pattern -> RST.Pattern
-  embedCore (RST.XtorPat loc xt args) = RST.XtorPat loc xt args
+  embedCore :: Core.Pattern -> RST.Pattern
+  embedCore (Core.XtorPat loc xt args) = RST.XtorPat loc xt args
 
 instance Desugar RST.PatternI Core.PatternI where
   desugar :: RST.PatternI -> Core.PatternI

--- a/src/Sugar/TST.hs
+++ b/src/Sugar/TST.hs
@@ -26,6 +26,7 @@ module Sugar.TST (
 import Syntax.TST.Terms
 import Syntax.CST.Names
 import Syntax.Core.Annot
+import Syntax.Core.Terms (Pattern(..))
 import Syntax.CST.Kinds
 import Loc
 import Syntax.TST.Types

--- a/src/Syntax/Core/Terms.hs
+++ b/src/Syntax/Core/Terms.hs
@@ -18,12 +18,11 @@ import Syntax.Core.Annot
 import Loc
 import Errors
 import Syntax.CST.Types (PrdCns(..), PrdCnsRep(..))
-import Syntax.TST.Terms (ShiftDirection(..))
 import Syntax.CST.Terms qualified as CST
 import Syntax.RST.Terms qualified as RST
 import Syntax.CST.Names
     ( ClassName, FreeVarName, Index, MethodName, XtorName )
-import Syntax.LocallyNameless (LocallyNameless (..), Shiftable (..))
+import Syntax.LocallyNameless (LocallyNameless (..), Shiftable (..), ShiftDirection(..))
 import Syntax.NMap (NMap (..), (<¢>))
 
 ---------------------------------------------------------------------------------
@@ -55,6 +54,11 @@ instance NMap Substitution PrdCnsTerm where
   nmap f = MkSubstitution . fmap f . unSubstitution
   nmapM f = fmap MkSubstitution . mapM f . unSubstitution
 
+data Pattern where
+  XtorPat :: Loc -> XtorName -> [(PrdCns, Maybe FreeVarName)] -> Pattern
+
+deriving instance Show Pattern
+
 -- | Represents one case in a pattern match or copattern match.
 --
 --        X Gamma           => c
@@ -64,7 +68,7 @@ instance NMap Substitution PrdCnsTerm where
 --
 data CmdCase = MkCmdCase
   { cmdcase_loc  :: Loc
-  , cmdcase_pat :: RST.Pattern
+  , cmdcase_pat :: Pattern
   , cmdcase_cmd  :: Command
   }
 
@@ -81,7 +85,7 @@ deriving instance Show CmdCase
 --
 data InstanceCase = MkInstanceCase
   { instancecase_loc :: Loc
-  , instancecase_pat :: RST.Pattern
+  , instancecase_pat :: Pattern
   , instancecase_cmd :: Command
   }
 
@@ -272,7 +276,7 @@ termLocallyClosedRec _ FreeVar{} = Right ()
 termLocallyClosedRec env (Xtor _ _ _ _ _ subst) = do
   sequence_ (pctermLocallyClosedRec env <$> unSubstitution subst)
 termLocallyClosedRec env (XCase _ _ _ _ cases) = do
-  sequence_ ((\MkCmdCase { cmdcase_cmd, cmdcase_pat = RST.XtorPat _ _ args } -> commandLocallyClosedRec (((\(x,_) -> (x,())) <$> args) : env) cmdcase_cmd) <$> cases)
+  sequence_ ((\MkCmdCase { cmdcase_cmd, cmdcase_pat = XtorPat _ _ args } -> commandLocallyClosedRec (((\(x,_) -> (x,())) <$> args) : env) cmdcase_cmd) <$> cases)
 termLocallyClosedRec env (MuAbs _ _ PrdRep _ cmd) = commandLocallyClosedRec ([(Cns,())] : env) cmd
 termLocallyClosedRec env (MuAbs _ _ CnsRep _ cmd) = commandLocallyClosedRec ([(Prd,())] : env) cmd
 termLocallyClosedRec _ (PrimLitI64 _ _) = Right ()

--- a/src/Syntax/Core/Terms.hs
+++ b/src/Syntax/Core/Terms.hs
@@ -6,6 +6,7 @@ module Syntax.Core.Terms
   , CmdCase(..)
   , InstanceCase(..)
   , Command(..)
+  , Pattern(..)
   -- Functions
   , termLocallyClosed
   ) where

--- a/src/Syntax/TST/Terms.hs
+++ b/src/Syntax/TST/Terms.hs
@@ -25,11 +25,13 @@ import Syntax.CST.Names
     ( ClassName, FreeVarName, Index, MethodName, XtorName )
 import Syntax.Core.Annot
     ( ApplyAnnot, MatchAnnot, MuAnnot, XtorAnnot )
+import Syntax.Core.Terms qualified as Core
 import Syntax.CST.Kinds ( MonoKind )
 import Syntax.CST.Terms qualified as CST
 import Syntax.CST.Types (PrdCns(..), PrdCnsRep(..))
 import Syntax.RST.Terms qualified as RST
 import Syntax.RST.Types (Polarity(..), PolarityRep(..))
+
 import Syntax.RST.Program (PrdCnsToPol)
 import Syntax.TST.Types
 import Data.Bifunctor (Bifunctor(second))
@@ -78,7 +80,7 @@ instance NMap Substitution PrdCnsTerm where
 --
 data CmdCase = MkCmdCase
   { cmdcase_loc  :: Loc
-  , cmdcase_pat :: RST.Pattern
+  , cmdcase_pat :: Core.Pattern
   , cmdcase_cmd  :: Command
   }
 
@@ -98,7 +100,7 @@ deriving instance Show CmdCase
 --
 data InstanceCase = MkInstanceCase
   { instancecase_loc :: Loc
-  , instancecase_pat :: RST.Pattern
+  , instancecase_pat :: Core.Pattern
   , instancecase_cmd :: Command
   }
 

--- a/src/Syntax/TST/Terms.hs
+++ b/src/Syntax/TST/Terms.hs
@@ -3,7 +3,6 @@ module Syntax.TST.Terms
     Term(..)
   , PrdCnsTerm(..)
   , Substitution(..)
-  , RST.Pattern(..)
   , CmdCase(..)
   , InstanceCase(..)
   , Command(..)
@@ -367,7 +366,7 @@ termLocallyClosedRec _ (PrimLitString _ _) = Right ()
 
 
 cmdCaseLocallyClosedRec :: [[(PrdCns,())]] -> CmdCase -> Either Error ()
-cmdCaseLocallyClosedRec env (MkCmdCase _ (RST.XtorPat _ _ args) cmd)= do
+cmdCaseLocallyClosedRec env (MkCmdCase _ (Core.XtorPat _ _ args) cmd)= do
   commandLocallyClosedRec (((\(x,_) -> (x,())) <$> args):env) cmd
 
 commandLocallyClosedRec :: [[(PrdCns,())]] -> Command -> Either Error ()
@@ -384,7 +383,7 @@ termLocallyClosed :: Term pc -> Either Error ()
 termLocallyClosed = termLocallyClosedRec []
 
 instanceCaseLocallyClosed :: InstanceCase -> Either Error ()
-instanceCaseLocallyClosed (MkInstanceCase _ (RST.XtorPat _ _ args) cmd) =
+instanceCaseLocallyClosed (MkInstanceCase _ (Core.XtorPat _ _ args) cmd) =
   commandLocallyClosedRec [second (const ()) <$> args] cmd
 
 ---------------------------------------------------------------------------------

--- a/src/Translate/Focusing.hs
+++ b/src/Translate/Focusing.hs
@@ -6,6 +6,7 @@ import Eval.Definition (EvalEnv)
 import Syntax.TST.Program
 import Syntax.TST.Terms
 import Syntax.TST.Types
+import Syntax.Core.Terms (Pattern(..))
 import Syntax.RST.Types (PolarityRep(..))
 import Syntax.RST.Terms qualified as RST
 import Loc

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -13,7 +13,6 @@ import Syntax.TST.Program qualified as TST
 import Syntax.TST.Types qualified as TST
 import Syntax.Core.Terms qualified as Core
 import Syntax.Core.Program qualified as Core
-import Syntax.RST.Terms qualified as RST
 import Syntax.RST.Types qualified as RST
 import Syntax.RST.Types (Polarity(..), PolarityRep(..))
 import Syntax.CST.Names
@@ -157,7 +156,7 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
   -- Structural pattern and copattern matches:
   --
   genConstraints (Core.XCase loc annot rep CST.Structural cases) = do
-    inferredCases <- forM cases (\Core.MkCmdCase{ cmdcase_pat = RST.XtorPat loc xt args, cmdcase_loc, cmdcase_cmd} -> do
+    inferredCases <- forM cases (\Core.MkCmdCase{ cmdcase_pat = Core.XtorPat loc xt args, cmdcase_loc, cmdcase_cmd} -> do
                         -- Generate positive and negative unification variables for all variables
                         -- bound in the pattern.
                         xtorKnd <- lookupXtorKind xt
@@ -167,7 +166,7 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
                         -- Check the command in the context extended with the positive unification variables
                         cmdInferred <- withContext uvarsPos (genConstraints cmdcase_cmd)
                         -- Return the negative unification variables in the returned type.
-                        return (TST.MkCmdCase cmdcase_loc (TST.XtorPat loc xt args) cmdInferred, TST.MkXtorSig xt uvarsNeg))
+                        return (TST.MkCmdCase cmdcase_loc (Core.XtorPat loc xt args) cmdInferred, TST.MkXtorSig xt uvarsNeg))
     let xtors = snd <$> inferredCases
     case rep of
       -- The return type is a structural type consisting of a XtorSig for each case.
@@ -188,15 +187,15 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
     throwGenError (EmptyNominalMatch loc)
   genConstraints (Core.XCase loc annot rep CST.Nominal cases@(pmcase:_)) = do
     -- We lookup the data declaration based on the first pattern match case.
-    decl <- lookupDataDecl loc (case Core.cmdcase_pat pmcase of (RST.XtorPat _ xt _) -> xt)
+    decl <- lookupDataDecl loc (case Core.cmdcase_pat pmcase of (Core.XtorPat _ xt _) -> xt)
     -- We check that all cases in the pattern match belong to the type declaration.
-    checkCorrectness loc ((\cs -> case Core.cmdcase_pat cs of RST.XtorPat _ xt _ -> xt) <$> cases) decl
+    checkCorrectness loc ((\cs -> case Core.cmdcase_pat cs of Core.XtorPat _ xt _ -> xt) <$> cases) decl
     -- We check that all xtors in the type declaration are matched against.
-    checkExhaustiveness loc ((\cs -> case Core.cmdcase_pat cs of RST.XtorPat _ xt _ -> xt) <$> cases) decl
+    checkExhaustiveness loc ((\cs -> case Core.cmdcase_pat cs of Core.XtorPat _ xt _ -> xt) <$> cases) decl
     -- Generate fresh unification variables for type parameters
     (args, tyParamsMap) <- freshTVarsForTypeParams (prdCnsToPol rep) decl
 
-    inferredCases <- forM cases (\Core.MkCmdCase {cmdcase_loc, cmdcase_pat = RST.XtorPat loc' xt args, cmdcase_cmd} -> do
+    inferredCases <- forM cases (\Core.MkCmdCase {cmdcase_loc, cmdcase_pat = Core.XtorPat loc' xt args, cmdcase_cmd} -> do
                     -- We lookup the types belonging to the xtor in the type declaration.
                     posTypes <- TST.sig_args <$> lookupXtorSig loc xt PosRep
                     negTypes <- TST.sig_args <$> lookupXtorSig loc xt NegRep
@@ -206,7 +205,7 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
                     -- We generate constraints for the command in the context extended
                     -- with the types from the signature.
                     cmdInferred <- withContext posTypes' (genConstraints cmdcase_cmd)
-                    return (TST.MkCmdCase cmdcase_loc (TST.XtorPat loc' xt args) cmdInferred, TST.MkXtorSig xt negTypes'))
+                    return (TST.MkCmdCase cmdcase_loc (Core.XtorPat loc' xt args) cmdInferred, TST.MkXtorSig xt negTypes'))
     knd <- getKindDecl decl
     case rep of
       PrdRep -> return $ TST.XCase loc annot rep (TST.TyNominal defaultLoc PosRep (fst knd) (TST.data_name decl) args) CST.Nominal (fst <$> inferredCases)
@@ -220,10 +219,10 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
     throwGenError (EmptyRefinementMatch loc)
   genConstraints (Core.XCase loc annot rep CST.Refinement cases@(pmcase:_)) = do
     -- We lookup the data declaration based on the first pattern match case.
-    decl <- lookupDataDecl loc (case Core.cmdcase_pat pmcase of (RST.XtorPat _ xt _) -> xt)
+    decl <- lookupDataDecl loc (case Core.cmdcase_pat pmcase of (Core.XtorPat _ xt _) -> xt)
     -- We check that all cases in the pattern match belong to the type declaration.
-    checkCorrectness loc ((\cs -> case Core.cmdcase_pat cs of RST.XtorPat _ xt _ -> xt) <$> cases) decl
-    inferredCases <- forM cases (\Core.MkCmdCase {cmdcase_loc, cmdcase_pat = RST.XtorPat loc xt args , cmdcase_cmd} -> do
+    checkCorrectness loc ((\cs -> case Core.cmdcase_pat cs of Core.XtorPat _ xt _ -> xt) <$> cases) decl
+    inferredCases <- forM cases (\Core.MkCmdCase {cmdcase_loc, cmdcase_pat = Core.XtorPat loc xt args , cmdcase_cmd} -> do
                         -- Generate positive and negative unification variables for all variables
                         -- bound in the pattern.
                         xtor <- lookupXtorSig loc xt RST.PosRep
@@ -243,7 +242,7 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
                         genConstraintsCtxts uvarsPos upperBound' (PatternMatchConstraint loc)
                         -- For the type, we return the unification variables which are now bounded by the least
                         -- and greatest type translation.
-                        return (TST.MkCmdCase cmdcase_loc (TST.XtorPat loc xt args) cmdInferred, TST.MkXtorSig xt uvarsNeg))
+                        return (TST.MkCmdCase cmdcase_loc (Core.XtorPat loc xt args) cmdInferred, TST.MkXtorSig xt uvarsNeg))
     knd <- getKindDecl decl
     case rep of
       PrdRep -> return $ TST.XCase loc annot rep (TST.TyCodataRefined defaultLoc PosRep (fst knd) (TST.data_name decl) (snd <$> inferredCases)) CST.Refinement (fst <$> inferredCases)
@@ -322,11 +321,11 @@ instance GenConstraints Core.InstanceDeclaration TST.InstanceDeclaration where
     decl <- lookupClassDecl instancedecl_loc instancedecl_name
     insertSkolemsClass decl
     -- We check that all implementations belong to the same type class.
-    checkInstanceCoverage instancedecl_loc decl ((\(RST.XtorPat _ xt _) -> MkMethodName $ unXtorName xt) . Core.instancecase_pat <$> instancedecl_cases) 
+    checkInstanceCoverage instancedecl_loc decl ((\(Core.XtorPat _ xt _) -> MkMethodName $ unXtorName xt) . Core.instancecase_pat <$> instancedecl_cases) 
     -- Generate fresh unification variables for type parameters
     instancety <- annotateKind instancedecl_typ
     let tyParamsMap = paramsMap (classdecl_kinds decl) [instancety] 
-    inferredCases <- forM instancedecl_cases (\Core.MkInstanceCase { instancecase_loc, instancecase_pat = RST.XtorPat loc xt args, instancecase_cmd } -> do
+    inferredCases <- forM instancedecl_cases (\Core.MkInstanceCase { instancecase_loc, instancecase_pat = Core.XtorPat loc xt args, instancecase_cmd } -> do
                     let mn :: MethodName = MkMethodName $ unXtorName xt
                     -- We lookup the types belonging to the xtor in the type declaration.
                     posTypes <- lookupMethodType instancecase_loc mn decl PosRep
@@ -341,7 +340,7 @@ instance GenConstraints Core.InstanceDeclaration TST.InstanceDeclaration where
                     cmdInferred <- withContext posTypes' (genConstraints instancecase_cmd)
                     genConstraintsCtxts posTypes' negTypes' (InstanceConstraint instancecase_loc)
                     pure TST.MkInstanceCase { instancecase_loc = instancecase_loc
-                                            , instancecase_pat = RST.XtorPat loc xt args
+                                            , instancecase_pat = Core.XtorPat loc xt args
                                             , instancecase_cmd = cmdInferred
                                             })
     pure TST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc

--- a/test/Spec/LocallyClosed.hs
+++ b/test/Spec/LocallyClosed.hs
@@ -7,7 +7,8 @@ import Test.Hspec
 
 import Pretty.Pretty ( ppPrintString )
 import Pretty.Errors ()
-import Syntax.TST.Terms ( InstanceCase (instancecase_pat), Term, termLocallyClosed, instanceCaseLocallyClosed, Pattern (XtorPat) )
+import Syntax.Core.Terms (Pattern(..))
+import Syntax.TST.Terms ( InstanceCase (instancecase_pat), Term, termLocallyClosed, instanceCaseLocallyClosed)
 import Syntax.TST.Program qualified as TST
 import Syntax.CST.Names
 import Syntax.CST.Types (PrdCns(..), PrdCnsRep(..))


### PR DESCRIPTION
Currently Core and TST use the pattern type from the RST. But since the pattern type in the RST is going to become much richer, we have to duplicate the current definition of RST in Core and use it there.