### PR TITLE
Add wildcard patterns

### DIFF
--- a/examples/ICFP/ParsimoniousFilter.duo
+++ b/examples/ICFP/ParsimoniousFilter.duo
@@ -8,7 +8,7 @@ import Codata.Par;
 
 def rec prd filterHelper := \p l => case l of {
     Nil => cocase {
-        MkPar(k1,*) => MkUnit
+        MkPar(_,*) => MkUnit
     },
     Cons(x,xs) => case p x of {
         True =>

--- a/src/Resolution/Pattern.hs
+++ b/src/Resolution/Pattern.hs
@@ -81,6 +81,7 @@ resolvePattern pc (CST.PatWildcard loc) = do
 
 fromVar :: RST.PatternNew -> ResolverM (Loc, PrdCns, FreeVarName)
 fromVar (RST.PatVar loc pc var) = pure (loc, pc, var)
+fromVar (RST.PatWildcard loc pc) = pure (loc, pc, MkFreeVarName "_")
 fromVar pat = throwOtherError (getLoc pat) ["Called function \"fromVar\" on pattern which is not a variable."]
 
 analyzeInstancePattern :: CST.Pattern -> ResolverM (Loc, XtorName, [(Loc, PrdCns, FreeVarName)])

--- a/std/Codata/Par.duo
+++ b/std/Codata/Par.duo
@@ -12,8 +12,8 @@ type operator ⅋ leftassoc at 3 := Par;
 
 -- | Injection into the right element of Par.
 def prd unit : forall a. a -> Bot ⅋ a :=
-  \x => cocase { MkPar(k_err,*) => x };
+  \x => cocase { MkPar(_,*) => x };
 
 -- | Injection into the left element of Par.
 def prd throw : forall a. a -> a ⅋ Bot :=
-  \x => cocase { MkPar(*,k_res) => x };
+  \x => cocase { MkPar(*,_) => x };

--- a/std/Data/BinaryTree.duo
+++ b/std/Data/BinaryTree.duo
@@ -13,7 +13,7 @@ data BinTree : (+a : CBV) -> CBV{
 def rec prd depth : forall a. BinTree(a) -> Nat :=
     \t => case t of {
         Leaf => Z,
-        Branch(left,val,right) => S(natmax (depth left) (depth right))
+        Branch(left,_,right) => S(natmax (depth left) (depth right))
 };
 
 def rec prd insertTree: forall a. BinTree(a) -> a -> BinTree(a) := 

--- a/std/Data/List.duo
+++ b/std/Data/List.duo
@@ -14,7 +14,7 @@ data List : (+a : CBV) -> CBV {
 def rec prd length : forall a. List(a) -> Nat :=
     \xs => case xs of {
         Nil => Z,
-        Cons(x, xs) => S(length xs)
+        Cons(_, xs) => S(length xs)
     };
 
 -- | Append two lists together.

--- a/std/Data/Maybe.duo
+++ b/std/Data/Maybe.duo
@@ -18,13 +18,13 @@ def prd maybe : forall a b. b -> (a -> b) -> Maybe(a) -> b :=
 def prd isJust : Maybe(Top) -> Bool :=
   \m => case m of {
     Nothing => False,
-    Just(y) => True
+    Just(_) => True
  };
 
  def prd isNothing : Maybe(Top) -> Bool :=
   \m => case m of {
     Nothing => True,
-    Just(y) => False
+    Just(_) => False
   };
 
 def prd fromMaybe : forall a. a -> Maybe(a) -> a :=

--- a/std/Data/Peano.duo
+++ b/std/Data/Peano.duo
@@ -21,7 +21,7 @@ def rec prd  mul : Nat -> Nat -> Nat :=
                     , S(n) => add m (mul n m)};
 
 def rec prd nateq : Nat -> Nat -> Bool :=
-  \n m => case n of { Z    => case m of { Z => True,  S(m) => False}
+  \n m => case n of { Z    => case m of { Z => True,  S(_) => False}
                     , S(n) => case m of { Z => False, S(m) => nateq n m}};
 
 def rec prd natmax : Nat -> Nat -> Nat := 

--- a/std/Data/PeanoRefinement.duo
+++ b/std/Data/PeanoRefinement.duo
@@ -20,5 +20,5 @@ def rec prd mul :=
                     , S(n) => add m (mul n m)};
 
 def rec prd nateq :=
-  \n m => case n of { Z    => case m of { Z => True,  S(m) => False}
+  \n m => case n of { Z    => case m of { Z => True,  S(_) => False}
                     , S(n) => case m of { Z => False, S(m) => nateq n m}};

--- a/std/Data/PeanoStructural.duo
+++ b/std/Data/PeanoStructural.duo
@@ -20,5 +20,5 @@ def rec prd mul :=
                     , S(n) => add m (mul n m)};
 
 def rec prd nateq :=
-  \n m => case n of { Z    => case m of { Z => True,  S(m) => False}
+  \n m => case n of { Z    => case m of { Z => True,  S(_) => False}
                     , S(n) => case m of { Z => False, S(m) => nateq n m}};

--- a/std/Data/Tensor.duo
+++ b/std/Data/Tensor.duo
@@ -11,8 +11,8 @@ type operator ⊗ leftassoc at 5 := Tensor;
 
 -- | First projection on Tensor.
 def prd fst : forall a. Tensor(a,Top) -> a :=
-  \p => case p of { MkTensor(x,y) => x};
+  \p => case p of { MkTensor(x,_) => x};
 
 -- | Second projection on Tensor
 def prd snd : forall a. Tensor(Top,a) -> a :=
-  \p => case p of { MkTensor(x,y) => y};
+  \p => case p of { MkTensor(_,y) => y};


### PR DESCRIPTION
We can now use wildcard patterns in pattern matches in some circumstances.
```
Allowed:
case x of { Z => ..., S(_) => ... }

Disallowed:
case x of { _ => ...}
case x of { Z => ...; _ => ... }
```