### PR TITLE
Improve debug output

### DIFF
--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -165,27 +165,19 @@ instance PrettyAnn SolverResult where
 ---------------------------------------------------------------------------------
 
 prettyBisubst :: (UniTVar, (TST.Typ 'Pos, TST.Typ 'Neg)) -> Doc Annotation
-prettyBisubst (v, (typ,tyn)) = nest 3 $ vsep ["Unification variable:" <+> prettyAnn v
-
-                                             , vsep [ "+ |->" <+> prettyAnn typ
-                                                    , "- |->" <+> prettyAnn tyn
-                                                    ]
-                                             ]
+prettyBisubst (v, (typ,tyn)) = nest 3 $ line <> vsep [ prettyAnn v <+> "+ ⤇" <+> prettyAnn typ
+                                                     , prettyAnn v <+> "- ⤇" <+> prettyAnn tyn
+                                                     ]
 
 prettyRecBisubst :: (RecTVar, (TST.Typ 'Pos, TST.Typ 'Neg)) -> Doc Annotation
-prettyRecBisubst (v, (typ,tyn)) = nest 3 $ vsep ["Recursive variable:" <+> prettyAnn v
+prettyRecBisubst (v, (typ,tyn)) = nest 3 $ line <> vsep [ prettyAnn v <+> "+ ⤇" <+> prettyAnn typ
+                                                        , prettyAnn v <+> "- ⤇" <+> prettyAnn tyn
+                                                        ]
 
-                                             , vsep [ "+ |->" <+> prettyAnn typ
-                                                    , "- |->" <+> prettyAnn tyn
-                                                    ]
-                                             ]
 prettySkolBisubst :: (SkolemTVar, (TST.Typ 'Pos, TST.Typ 'Neg)) -> Doc Annotation
-prettySkolBisubst (v, (typ,tyn)) = nest 3 $ vsep ["Skolem variable:" <+> prettyAnn v
-
-                                             , vsep [ "+ |->" <+> prettyAnn typ
-                                                    , "- |->" <+> prettyAnn tyn
-                                                    ]
-                                             ]
+prettySkolBisubst (v, (typ,tyn)) = nest 3 $ line <> vsep [ prettyAnn v <+> "+ ⤇" <+> prettyAnn typ
+                                                         , prettyAnn v <+> "- ⤇" <+> prettyAnn tyn
+                                                         ]
 
 prettyKindSubst :: (KVar, MonoKind) -> Doc Annotation
 prettyKindSubst (kv, kind) = nest 3 $ vsep ["Kind Variable:" <+> prettyAnn kv <+> "->" <+> prettyAnn kind ]
@@ -195,7 +187,7 @@ instance PrettyAnn (TST.Bisubstitution TST.UniVT) where
     [ headerise "-" " " "Bisubstitution (UniTVar)"
     , "" 
     , "Unification Variables: "
-    , vsep $ intersperse "" (prettyBisubst <$> M.toList (fst (TST.bisubst_map uvsubst)))
+    , vsep $ prettyBisubst <$> M.toList (fst (TST.bisubst_map uvsubst))
     , ""
     , "Kind Variables: "
     , vsep $ intersperse "" (prettyKindSubst <$> M.toList (snd (TST.bisubst_map uvsubst)))
@@ -205,13 +197,13 @@ instance PrettyAnn (TST.Bisubstitution TST.SkolemVT) where
   prettyAnn skolvsubst = vsep 
     [ headerise "-" " " "Bisubstitution (SkolemTVar)"
     , ""
-    , vsep $ intersperse "" (prettySkolBisubst <$> M.toList (TST.bisubst_map skolvsubst))
+    , vsep $ prettySkolBisubst <$> M.toList (TST.bisubst_map skolvsubst)
     ]
 
 instance PrettyAnn (TST.Bisubstitution TST.RecVT) where
   prettyAnn recvsubst = vsep
     [ headerise "-" " " "Bisubstitution (RecTVar)"
     , ""
-    , vsep $ intersperse "" (prettyRecBisubst <$> M.toList (TST.bisubst_map recvsubst))
+    , vsep $ prettyRecBisubst <$> M.toList (TST.bisubst_map recvsubst)
     ]
 

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -7,12 +7,10 @@ import Data.Map qualified as M
 import Pretty.Pretty
 import Pretty.Types ()
 import Syntax.TST.Types qualified as TST
-import Syntax.RST.Types qualified as RST
 import Syntax.RST.Types (Polarity(..))
 import Syntax.CST.Names
 import TypeInference.Constraints
 import Syntax.CST.Kinds
-import Translate.EmbedTST (EmbedTST(..))
 
 ---------------------------------------------------------------------------------
 -- Generated Constraints
@@ -106,25 +104,19 @@ instance PrettyAnn SubtypeWitness where
 -- Solved Constraints
 ---------------------------------------------------------------------------------
 
-printRSTLowerBounds :: [RST.Typ 'Pos] -> Doc Annotation
-printRSTLowerBounds [] = mempty
-printRSTLowerBounds lowerbounds =
+printLowerBounds :: [TST.Typ 'Pos] -> Doc Annotation
+printLowerBounds [] = mempty
+printLowerBounds lowerbounds =
   nest 3 $ vsep [ "Lower bounds:"
                 ,  vsep (prettyAnn <$> lowerbounds)
                 ]
 
-printRSTUpperBounds :: [RST.Typ 'Neg] -> Doc Annotation
-printRSTUpperBounds [] = mempty
-printRSTUpperBounds upperbounds =
+printUpperBounds :: [TST.Typ 'Neg] -> Doc Annotation
+printUpperBounds [] = mempty
+printUpperBounds upperbounds =
   nest 3 $ vsep [ "Upper bounds:"
                 , vsep (prettyAnn <$> upperbounds)
                 ]
-
-printTSTLowerBounds :: [TST.Typ 'Pos] -> Doc Annotation
-printTSTLowerBounds ls = printRSTLowerBounds (map embedTST ls)
-
-printTSTUpperBounds :: [TST.Typ 'Neg] -> Doc Annotation
-printTSTUpperBounds ls = printRSTUpperBounds (map embedTST ls)
 
 printTypeClassConstraints :: [ClassName] -> Doc Annotation
 printTypeClassConstraints [] = mempty
@@ -139,17 +131,18 @@ instance PrettyAnn VariableState where
   prettyAnn VariableState { vst_lowerbounds = []  , vst_upperbounds = []  , vst_typeclasses = cns } =
     printTypeClassConstraints cns
   prettyAnn VariableState { vst_lowerbounds = lbs , vst_upperbounds = []  , vst_typeclasses = []  } =
-    printTSTLowerBounds lbs
+    printLowerBounds lbs
   prettyAnn VariableState { vst_lowerbounds = lbs , vst_upperbounds = []  , vst_typeclasses = cns } =
-    printTSTLowerBounds lbs <> line <> printTypeClassConstraints cns
+    printLowerBounds lbs <> line <> printTypeClassConstraints cns
   prettyAnn VariableState { vst_lowerbounds = []  , vst_upperbounds = ubs , vst_typeclasses = []  } =
-    printTSTUpperBounds ubs
+    printUpperBounds ubs
   prettyAnn VariableState { vst_lowerbounds = []  , vst_upperbounds = ubs , vst_typeclasses = cns } =
-    printTSTUpperBounds ubs <> line <> printTypeClassConstraints cns
+    printUpperBounds ubs <> line <> printTypeClassConstraints cns
   prettyAnn VariableState { vst_lowerbounds = lbs , vst_upperbounds = ubs , vst_typeclasses = []  } =
-    printTSTLowerBounds lbs <> line <> printTSTUpperBounds ubs
+    printLowerBounds lbs <> line <> printUpperBounds ubs
   prettyAnn VariableState { vst_lowerbounds = lbs , vst_upperbounds = ubs , vst_typeclasses = cns } =
-    printTSTLowerBounds lbs <> line <> printTSTUpperBounds ubs <> line <> printTypeClassConstraints cns
+    printLowerBounds lbs <> line <> printUpperBounds ubs <> line <> printTypeClassConstraints cns
+
 instance PrettyAnn SolverResult where
   prettyAnn MkSolverResult { tvarSolution, witnessSolution } = vsep
     

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -106,10 +106,8 @@ instance PrettyAnn SubtypeWitness where
 
 printBounds :: PolarityRep pc -> UniTVar -> [TST.Typ pc] -> Doc Annotation
 printBounds _ _ [] = mempty
-printBounds pc u bounds =
-  nest 3 $ vsep [ prettyAnn u <+> (case pc of PosRep -> "lower bounds:"; NegRep -> "upper bounds:")
-                , vsep (prettyAnn <$> bounds)
-                ]
+printBounds pc u bounds = prettyAnn u <+> (case pc of PosRep -> "lower bounds:"; NegRep -> "upper bounds:") <> (mkParen True mempty mempty  comma (prettyAnn <$> bounds))
+                
 
 printTypeClassConstraints :: UniTVar -> [ClassName] -> Doc Annotation
 printTypeClassConstraints _ [] = mempty


### PR DESCRIPTION
Save vertical space when prettyprinting debug output:

# Solved constraints
### Before
```
------------------------------------------------------------
                     Solved Constraints                     
------------------------------------------------------------

Type variable: u0
   Lower bounds:
      Nat
   Upper bounds:
      u4
      Nat

Type variable: u1
   Lower bounds:
      Bool
   Upper bounds:
      Bool

Type variable: u2
   Lower bounds:
      (Nat -> Bool)
   Upper bounds:
      (u6 -> u5)

Type variable: u3
   Lower bounds:
      (Nat -> Bool)
   Upper bounds:
      u2

Type variable: u4
   Lower bounds:
      Nat
   Upper bounds:
      Nat

Type variable: u5
   Lower bounds:
      Bool
   Upper bounds:
      u1

Type variable: u6
   Lower bounds:
      Nat
   Upper bounds:
      Nat

```
### After
```
------------------------------------------------------------
                     Solved Constraints                     
------------------------------------------------------------

u0 lower bounds: Nat 
u0 upper bounds: u4 , Nat 

u1 lower bounds: Bool 
u1 upper bounds: Bool 

u2 lower bounds: (Nat -> Bool) 
u2 upper bounds: (u6 -> u5) 

u3 lower bounds: (Nat -> Bool) 
u3 upper bounds: u2 

u4 lower bounds: Nat 
u4 upper bounds: Nat 

u5 lower bounds: Bool 
u5 upper bounds: u1 

u6 lower bounds: Nat 
u6 upper bounds: Nat 

```

# Bisubstitution
### Before
```
------------------------------------------------------------
                  Bisubstitution (UniTVar)                  
------------------------------------------------------------

Unification Variables: 
Unification variable: u0
   + |-> (s0 ∨ Nat)
   - |-> (s0 ∧ ((s1 ∧ Nat) ∧ Nat))

Unification variable: u1
   + |-> (s2 ∨ Bool)
   - |-> (s2 ∧ Bool)

Unification variable: u2
   + |-> (s3 ∨ (Nat -> Bool))
   - |-> (s3 ∧ ((s4 ∨ Nat) -> (s5 ∧ (s2 ∧ Bool))))

Unification variable: u3
   + |-> (s6 ∨ (Nat -> Bool))
   - |-> (s6 ∧ (s3 ∧ ((s4 ∨ Nat) -> (s5 ∧ (s2 ∧ Bool)))))

Unification variable: u4
   + |-> (s1 ∨ Nat)
   - |-> (s1 ∧ Nat)

Unification variable: u5
   + |-> (s5 ∨ Bool)
   - |-> (s5 ∧ (s2 ∧ Bool))

Unification variable: u6
   + |-> (s4 ∨ Nat)
   - |-> (s4 ∧ Nat)

```
### After
```
------------------------------------------------------------
                  Bisubstitution (UniTVar)                  
------------------------------------------------------------

Unification Variables: 

   u0 + ⤇ (s0 ∨ Nat)
   u0 - ⤇ (s0 ∧ ((s1 ∧ Nat) ∧ Nat))

   u1 + ⤇ (s2 ∨ Bool)
   u1 - ⤇ (s2 ∧ Bool)

   u2 + ⤇ (s3 ∨ (Nat -> Bool))
   u2 - ⤇ (s3 ∧ ((s4 ∨ Nat) -> (s5 ∧ (s2 ∧ Bool))))

   u3 + ⤇ (s6 ∨ (Nat -> Bool))
   u3 - ⤇ (s6 ∧ (s3 ∧ ((s4 ∨ Nat) -> (s5 ∧ (s2 ∧ Bool)))))

   u4 + ⤇ (s1 ∨ Nat)
   u4 - ⤇ (s1 ∧ Nat)

   u5 + ⤇ (s5 ∨ Bool)
   u5 - ⤇ (s5 ∧ (s2 ∧ Bool))

   u6 + ⤇ (s4 ∨ Nat)
   u6 - ⤇ (s4 ∧ Nat)


```
