### PR TITLE
Use named instances

### DIFF
--- a/examples/Ord.duo
+++ b/examples/Ord.duo
@@ -12,7 +12,7 @@ class Ord(+a : CBV) {
     Compare(a, a, return Ordering)
 };
 
-instance Ord Ordering {
+instance ordOrdering : Ord Ordering {
     Compare(x,y,k) => case x of {
         LT => case y of {
             LT => EQ,
@@ -32,7 +32,7 @@ instance Ord Ordering {
     } >> k
 };
 
-instance Ord Bool {
+instance ordBool : Ord Bool {
     Compare(x,y,k) => case x of {
         True => case y of {
             True => EQ,

--- a/examples/TypeClassInstance.duo
+++ b/examples/TypeClassInstance.duo
@@ -12,13 +12,13 @@ class Eq(+a : CBV) {
 
 
 -- | Bool instance definition.
-instance Eq Bool {
+instance eqBool : Eq Bool {
   Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
   Differ(x, y, k) => and (or x y) (not (and x y)) >> k
 };
 
 -- | Nat instance definition.
-instance Eq Nat {
+instance eqNat : Eq Nat {
   Equals(x, y, k) => nateq x y >> k,
   Differ(x, y, k) => not (nateq x y) >> k
 };
@@ -27,7 +27,7 @@ class Show(+a : CBV) {
   Show(a)
 };
 
-instance Show Bool {
+instance showBool : Show Bool {
   Show(x) => #Print(x, #ExitSuccess)
 };
 
@@ -35,7 +35,7 @@ class Reader(-a : CBV) {
   Reader(Bool, return a)
 };
 
-instance Reader Bool {
+instance readerBool : Reader Bool {
   Reader(x, k) => x >> k
 };
 

--- a/examples/TypeClasses.duo
+++ b/examples/TypeClasses.duo
@@ -12,7 +12,7 @@ class Eq(+a : CBV) {
 
 
 -- | Instance definition.
-instance Eq Bool {
+instance eqBool : Eq Bool {
   Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
   Differ(x, y, k) => and (or x y) (not (and x y)) >> k
 };

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -168,14 +168,14 @@ inferCommandDeclaration mn Core.MkCommandDeclaration { cmddecl_loc, cmddecl_doc,
 inferInstanceDeclaration :: ModuleName
                         -> Core.InstanceDeclaration
                         -> DriverM TST.InstanceDeclaration
-inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_name, instancedecl_typ } = do
+inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_class, instancedecl_typ } = do
   env <- gets drvEnv
   -- Generate the constraints
   (instanceInferred,constraints) <- liftEitherErr (runGenM instancedecl_loc env (genConstraints decl))
   -- Solve the constraints
   solverResult <- liftEitherErrLoc instancedecl_loc $ solveConstraints constraints env
   guardVerbose $ do
-    ppPrintIO (Header  $ unClassName instancedecl_name <> " " <> ppPrint (fst instancedecl_typ))
+    ppPrintIO (Header  $ unClassName instancedecl_class <> " " <> ppPrint (fst instancedecl_typ))
     ppPrintIO ("" :: T.Text)
     ppPrintIO (Core.InstanceDecl decl)
     ppPrintIO ("" :: T.Text)
@@ -183,7 +183,7 @@ inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, 
     ppPrintIO solverResult
   -- Insert into environment
   let instty' = TST.instancedecl_typ instanceInferred
-  let f env = env { instanceEnv = M.adjust (S.insert instty') instancedecl_name (instanceEnv env)}
+  let f env = env { instanceEnv = M.adjust (S.insert instty') instancedecl_class (instanceEnv env)}
   modifyEnvironment mn f
   pure instanceInferred
 

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -303,14 +303,15 @@ instanceDeclarationP doc = do
   try (void (keywordP KwInstance))
   sc
   recoverDeclaration $ do
-    className  <- fst <$> (classNameP <* sc)
-    typ        <- fst <$> typP
-    (cases, _) <- bracesP (termCaseP `sepBy` (symbolP SymComma >> sc))
+    instanceName <- fst <$> (freeVarNameP <* sc)
+    className    <- fst <$> (classNameP <* sc)
+    typ          <- fst <$> typP
+    (cases, _)   <- bracesP (termCaseP `sepBy` (symbolP SymComma >> sc))
     sc
     symbolP SymSemi
     endPos <- getSourcePos
     sc
-    let decl = MkInstanceDeclaration (Loc startPos endPos) doc className typ cases
+    let decl = MkInstanceDeclaration (Loc startPos endPos) doc instanceName className typ cases
     pure (InstanceDecl decl)
 
 

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -304,6 +304,7 @@ instanceDeclarationP doc = do
   sc
   recoverDeclaration $ do
     instanceName <- fst <$> (freeVarNameP <* sc)
+    symbolP SymColon <* sc
     className    <- fst <$> (classNameP <* sc)
     typ          <- fst <$> typP
     (cases, _)   <- bracesP (termCaseP `sepBy` (symbolP SymComma >> sc))

--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -177,9 +177,9 @@ instance PrettyAnn CST.ClassDeclaration where
 ---------------------------------------------------------------------------------
 
 instance PrettyAnn CST.InstanceDeclaration where
-  prettyAnn CST.MkInstanceDeclaration { instancedecl_name, instancedecl_typ, instancedecl_cases } =
+  prettyAnn CST.MkInstanceDeclaration { instancedecl_class, instancedecl_typ, instancedecl_cases } =
     annKeyword "instance" <+>
-    prettyAnn instancedecl_name <+>
+    prettyAnn instancedecl_class <+>
     prettyAnn instancedecl_typ <+>
     braces (group (nest 3 (line' <> vsep (punctuate comma (prettyAnn <$> instancedecl_cases))))) <>
     semi

--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -177,8 +177,9 @@ instance PrettyAnn CST.ClassDeclaration where
 ---------------------------------------------------------------------------------
 
 instance PrettyAnn CST.InstanceDeclaration where
-  prettyAnn CST.MkInstanceDeclaration { instancedecl_class, instancedecl_typ, instancedecl_cases } =
+  prettyAnn CST.MkInstanceDeclaration { instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     annKeyword "instance" <+>
+    prettyAnn instancedecl_name <+> annSymbol ":" <+>
     prettyAnn instancedecl_class <+>
     prettyAnn instancedecl_typ <+>
     braces (group (nest 3 (line' <> vsep (punctuate comma (prettyAnn <$> instancedecl_cases))))) <>

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -284,12 +284,13 @@ resolveClassDeclaration CST.MkClassDeclaration { classdecl_loc, classdecl_doc, c
 
 resolveInstanceDeclaration :: CST.InstanceDeclaration
                         -> ResolverM RST.InstanceDeclaration
-resolveInstanceDeclaration CST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
+resolveInstanceDeclaration CST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
   typ <- resolveTyp PosRep instancedecl_typ
   tyn <- resolveTyp NegRep instancedecl_typ
   tc <- mapM resolveInstanceCase instancedecl_cases
   pure RST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                  , instancedecl_doc = instancedecl_doc
+                                 , instancedecl_name = instancedecl_name
                                  , instancedecl_class = instancedecl_class
                                  , instancedecl_typ = (typ, tyn)
                                  , instancedecl_cases = tc

--- a/src/Resolution/Program.hs
+++ b/src/Resolution/Program.hs
@@ -284,13 +284,13 @@ resolveClassDeclaration CST.MkClassDeclaration { classdecl_loc, classdecl_doc, c
 
 resolveInstanceDeclaration :: CST.InstanceDeclaration
                         -> ResolverM RST.InstanceDeclaration
-resolveInstanceDeclaration CST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } = do
+resolveInstanceDeclaration CST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
   typ <- resolveTyp PosRep instancedecl_typ
   tyn <- resolveTyp NegRep instancedecl_typ
   tc <- mapM resolveInstanceCase instancedecl_cases
   pure RST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                  , instancedecl_doc = instancedecl_doc
-                                 , instancedecl_name = instancedecl_name
+                                 , instancedecl_class = instancedecl_class
                                  , instancedecl_typ = (typ, tyn)
                                  , instancedecl_cases = tc
                                  }

--- a/src/Resolution/Unresolve.hs
+++ b/src/Resolution/Unresolve.hs
@@ -707,12 +707,12 @@ instance Unresolve RST.ClassDeclaration CST.ClassDeclaration where
 
 instance Unresolve RST.InstanceDeclaration CST.InstanceDeclaration where
   unresolve :: RST.InstanceDeclaration -> UnresolveM CST.InstanceDeclaration
-  unresolve RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } = do
+  unresolve RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
     typ' <- unresolve (fst instancedecl_typ)
     cases' <- mapM unresolve instancedecl_cases
     pure $ CST.MkInstanceDeclaration { instancedecl_loc   = instancedecl_loc
                                      , instancedecl_doc   = instancedecl_doc
-                                     , instancedecl_name  = instancedecl_name
+                                     , instancedecl_class  = instancedecl_class
                                      , instancedecl_typ   = typ'
                                      , instancedecl_cases = cases'
                                      }

--- a/src/Resolution/Unresolve.hs
+++ b/src/Resolution/Unresolve.hs
@@ -707,12 +707,13 @@ instance Unresolve RST.ClassDeclaration CST.ClassDeclaration where
 
 instance Unresolve RST.InstanceDeclaration CST.InstanceDeclaration where
   unresolve :: RST.InstanceDeclaration -> UnresolveM CST.InstanceDeclaration
-  unresolve RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
+  unresolve RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
     typ' <- unresolve (fst instancedecl_typ)
     cases' <- mapM unresolve instancedecl_cases
     pure $ CST.MkInstanceDeclaration { instancedecl_loc   = instancedecl_loc
                                      , instancedecl_doc   = instancedecl_doc
-                                     , instancedecl_class  = instancedecl_class
+                                     , instancedecl_name  = instancedecl_name
+                                     , instancedecl_class = instancedecl_class
                                      , instancedecl_typ   = typ'
                                      , instancedecl_cases = cases'
                                      }

--- a/src/Sugar/Desugar.hs
+++ b/src/Sugar/Desugar.hs
@@ -317,19 +317,19 @@ instance Desugar RST.CommandDeclaration Core.CommandDeclaration where
 
 instance Desugar RST.InstanceDeclaration Core.InstanceDeclaration where
   desugar :: RST.InstanceDeclaration -> Core.InstanceDeclaration
-  desugar RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } =
+  desugar RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     Core.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                , instancedecl_doc = instancedecl_doc
-                               , instancedecl_name = instancedecl_name
+                               , instancedecl_class = instancedecl_class
                                , instancedecl_typ = instancedecl_typ
                                , instancedecl_cases = desugar <$> instancedecl_cases
                                }
 
   embedCore :: Core.InstanceDeclaration -> RST.InstanceDeclaration
-  embedCore Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } =
+  embedCore Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     RST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                               , instancedecl_doc = instancedecl_doc
-                              , instancedecl_name = instancedecl_name
+                              , instancedecl_class = instancedecl_class
                               , instancedecl_typ = instancedecl_typ
                               , instancedecl_cases = embedCore <$> instancedecl_cases
                               }

--- a/src/Sugar/Desugar.hs
+++ b/src/Sugar/Desugar.hs
@@ -317,18 +317,20 @@ instance Desugar RST.CommandDeclaration Core.CommandDeclaration where
 
 instance Desugar RST.InstanceDeclaration Core.InstanceDeclaration where
   desugar :: RST.InstanceDeclaration -> Core.InstanceDeclaration
-  desugar RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
+  desugar RST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     Core.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                , instancedecl_doc = instancedecl_doc
+                               , instancedecl_name = instancedecl_name
                                , instancedecl_class = instancedecl_class
                                , instancedecl_typ = instancedecl_typ
                                , instancedecl_cases = desugar <$> instancedecl_cases
                                }
 
   embedCore :: Core.InstanceDeclaration -> RST.InstanceDeclaration
-  embedCore Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
+  embedCore Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     RST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                               , instancedecl_doc = instancedecl_doc
+                              , instancedecl_name = instancedecl_name
                               , instancedecl_class = instancedecl_class
                               , instancedecl_typ = instancedecl_typ
                               , instancedecl_cases = embedCore <$> instancedecl_cases

--- a/src/Syntax/CST/Program.hs
+++ b/src/Syntax/CST/Program.hs
@@ -205,7 +205,7 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
-  , instancedecl_name :: ClassName
+  , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: Typ
     -- ^ The type the instance is being defined for.

--- a/src/Syntax/CST/Program.hs
+++ b/src/Syntax/CST/Program.hs
@@ -205,6 +205,8 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
+  , instancedecl_name :: FreeVarName
+    -- ^ The name of the instance declaration.
   , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: Typ

--- a/src/Syntax/Core/Program.hs
+++ b/src/Syntax/Core/Program.hs
@@ -61,6 +61,8 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
+  , instancedecl_name :: FreeVarName
+    -- ^ The name of the instance declaration.
   , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: (RST.Typ Pos, RST.Typ Neg)

--- a/src/Syntax/Core/Program.hs
+++ b/src/Syntax/Core/Program.hs
@@ -61,7 +61,7 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
-  , instancedecl_name :: ClassName
+  , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: (RST.Typ Pos, RST.Typ Neg)
     -- ^ The type the instance is being defined for.

--- a/src/Syntax/RST/Program.hs
+++ b/src/Syntax/RST/Program.hs
@@ -154,7 +154,7 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
-  , instancedecl_name :: ClassName
+  , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: (Typ Pos, Typ Neg)
     -- ^ The type the instance is being defined for.

--- a/src/Syntax/RST/Program.hs
+++ b/src/Syntax/RST/Program.hs
@@ -154,6 +154,8 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
+  , instancedecl_name :: FreeVarName
+    -- ^ The name of the instance declaration.
   , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: (Typ Pos, Typ Neg)

--- a/src/Syntax/TST/Program.hs
+++ b/src/Syntax/TST/Program.hs
@@ -64,6 +64,8 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
+  , instancedecl_name :: FreeVarName
+    -- ^ The name of the instance declaration.
   , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: (Typ Pos, Typ Neg)

--- a/src/Syntax/TST/Program.hs
+++ b/src/Syntax/TST/Program.hs
@@ -64,7 +64,7 @@ data InstanceDeclaration = MkInstanceDeclaration
     -- ^ The source code location of the declaration.
   , instancedecl_doc :: Maybe DocComment
     -- ^ The documentation string of the declaration.
-  , instancedecl_name :: ClassName
+  , instancedecl_class :: ClassName
     -- ^ The name of the type class the instance is for.
   , instancedecl_typ :: (Typ Pos, Typ Neg)
     -- ^ The type the instance is being defined for.

--- a/src/Translate/EmbedTST.hs
+++ b/src/Translate/EmbedTST.hs
@@ -195,10 +195,10 @@ instance EmbedTST TST.CommandDeclaration Core.CommandDeclaration where
 
 instance EmbedTST TST.InstanceDeclaration Core.InstanceDeclaration where
   embedTST  :: TST.InstanceDeclaration -> Core.InstanceDeclaration
-  embedTST  TST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } =
+  embedTST  TST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
       Core.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                  , instancedecl_doc = instancedecl_doc
-                                 , instancedecl_name = instancedecl_name
+                                 , instancedecl_class = instancedecl_class
                                  , instancedecl_typ = BF.bimap embedTST embedTST instancedecl_typ
                                  , instancedecl_cases = embedTST <$> instancedecl_cases
                                  }

--- a/src/Translate/EmbedTST.hs
+++ b/src/Translate/EmbedTST.hs
@@ -195,9 +195,10 @@ instance EmbedTST TST.CommandDeclaration Core.CommandDeclaration where
 
 instance EmbedTST TST.InstanceDeclaration Core.InstanceDeclaration where
   embedTST  :: TST.InstanceDeclaration -> Core.InstanceDeclaration
-  embedTST  TST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
+  embedTST  TST.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } =
       Core.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                  , instancedecl_doc = instancedecl_doc
+                                 , instancedecl_name = instancedecl_name
                                  , instancedecl_class = instancedecl_class
                                  , instancedecl_typ = BF.bimap embedTST embedTST instancedecl_typ
                                  , instancedecl_cases = embedTST <$> instancedecl_cases

--- a/src/Translate/Focusing.hs
+++ b/src/Translate/Focusing.hs
@@ -305,10 +305,10 @@ instance Focus CommandDeclaration where
 
 instance Focus InstanceDeclaration where
   focus :: EvaluationOrder -> InstanceDeclaration -> InstanceDeclaration
-  focus eo MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } =
+  focus eo MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     MkInstanceDeclaration { instancedecl_loc
                           , instancedecl_doc
-                          , instancedecl_name
+                          , instancedecl_class
                           , instancedecl_typ
                           , instancedecl_cases = focus eo <$> instancedecl_cases
                           }

--- a/src/Translate/Focusing.hs
+++ b/src/Translate/Focusing.hs
@@ -305,17 +305,18 @@ instance Focus CommandDeclaration where
 
 instance Focus InstanceDeclaration where
   focus :: EvaluationOrder -> InstanceDeclaration -> InstanceDeclaration
-  focus eo MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } =
+  focus eo MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } =
     MkInstanceDeclaration { instancedecl_loc
                           , instancedecl_doc
+                          , instancedecl_name
                           , instancedecl_class
                           , instancedecl_typ
                           , instancedecl_cases = focus eo <$> instancedecl_cases
                           }
   
   isFocused :: EvaluationOrder -> InstanceDeclaration -> Maybe InstanceDeclaration
-  isFocused eo (MkInstanceDeclaration loc doc name typ cases) =
-    MkInstanceDeclaration loc doc name typ <$> mapM (isFocused eo) cases
+  isFocused eo (MkInstanceDeclaration loc doc name iclass typ cases) =
+    MkInstanceDeclaration loc doc name iclass typ <$> mapM (isFocused eo) cases
 
 instance Focus Declaration where
   focus :: EvaluationOrder -> Declaration -> Declaration

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -316,7 +316,7 @@ instance GenConstraints Core.Command TST.Command where
   
 instance GenConstraints Core.InstanceDeclaration TST.InstanceDeclaration where
   genConstraints :: Core.InstanceDeclaration -> GenM TST.InstanceDeclaration
-  genConstraints Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
+  genConstraints Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
     -- We lookup the class declaration  of the instance.
     decl <- lookupClassDecl instancedecl_loc instancedecl_class
     insertSkolemsClass decl
@@ -344,11 +344,12 @@ instance GenConstraints Core.InstanceDeclaration TST.InstanceDeclaration where
                                             , instancecase_cmd = cmdInferred
                                             })
     pure TST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
-                                  , instancedecl_doc = instancedecl_doc
-                                  , instancedecl_class = instancedecl_class
-                                  , instancedecl_typ = instancety
-                                  , instancedecl_cases = inferredCases
-                                  }
+                                   , instancedecl_doc = instancedecl_doc
+                                   , instancedecl_name = instancedecl_name
+                                   , instancedecl_class = instancedecl_class
+                                   , instancedecl_typ = instancety
+                                   , instancedecl_cases = inferredCases
+                                   }
 
 
 

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -316,9 +316,9 @@ instance GenConstraints Core.Command TST.Command where
   
 instance GenConstraints Core.InstanceDeclaration TST.InstanceDeclaration where
   genConstraints :: Core.InstanceDeclaration -> GenM TST.InstanceDeclaration
-  genConstraints Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_name, instancedecl_typ, instancedecl_cases } = do
+  genConstraints Core.MkInstanceDeclaration { instancedecl_loc, instancedecl_doc, instancedecl_class, instancedecl_typ, instancedecl_cases } = do
     -- We lookup the class declaration  of the instance.
-    decl <- lookupClassDecl instancedecl_loc instancedecl_name
+    decl <- lookupClassDecl instancedecl_loc instancedecl_class
     insertSkolemsClass decl
     -- We check that all implementations belong to the same type class.
     checkInstanceCoverage instancedecl_loc decl ((\(Core.XtorPat _ xt _) -> MkMethodName $ unXtorName xt) . Core.instancecase_pat <$> instancedecl_cases) 
@@ -345,7 +345,7 @@ instance GenConstraints Core.InstanceDeclaration TST.InstanceDeclaration where
                                             })
     pure TST.MkInstanceDeclaration { instancedecl_loc = instancedecl_loc
                                   , instancedecl_doc = instancedecl_doc
-                                  , instancedecl_name = instancedecl_name
+                                  , instancedecl_class = instancedecl_class
                                   , instancedecl_typ = instancety
                                   , instancedecl_cases = inferredCases
                                   }

--- a/test/Counterexamples/CE_048.duo
+++ b/test/Counterexamples/CE_048.duo
@@ -10,6 +10,6 @@ class Eq(+a : CBV) {
   Differ(a, a, return Bool)
 };
 
-instance Eq Bool {
+instance eqBool : Eq Bool {
   Equals(x, y, k) => or (and x y) (not (or x y)) >> k
 };

--- a/test/Counterexamples/CE_049.duo
+++ b/test/Counterexamples/CE_049.duo
@@ -9,7 +9,7 @@ class Eq(+a : CBV) {
   Differ(a, a, return Bool)
 };
 
-instance Eq Bool {
+instance eqBool : Eq Bool {
   Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
   Differ(x, y, k) => Cons((or x y), (not (and x y))) >> k
 };

--- a/test/Counterexamples/CE_050.duo
+++ b/test/Counterexamples/CE_050.duo
@@ -13,7 +13,7 @@ class Eq(+a : CBV) {
 
 
 -- | Nat instance definition.
-instance Eq Nat {
+instance eqNat : Eq Nat {
   Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
   Differ(x, y, k) => and (or x y) (not (and x y)) >> k
 };

--- a/test/Spec/LocallyClosed.hs
+++ b/test/Spec/LocallyClosed.hs
@@ -34,7 +34,7 @@ getInstanceCases TST.MkModule { mod_decls } = go mod_decls []
   where
     go :: [TST.Declaration] -> [InstanceCase] -> [InstanceCase]
     go [] acc = acc
-    go ((TST.InstanceDecl (TST.MkInstanceDeclaration _ _ _ _ cases)):rest) acc = go rest (cases++acc)
+    go ((TST.InstanceDecl (TST.MkInstanceDeclaration _ _ _ _ _ cases)):rest) acc = go rest (cases++acc)
     go (_:rest) acc = go rest acc
 
 spec :: [((FilePath, ModuleName), Either (NonEmpty Error) TST.Module)] -> Spec


### PR DESCRIPTION
Previously instances were anonymous, e.g.
```
instance Eq Bool {
  Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
  Differ(x, y, k) => and (or x y) (not (and x y)) >> k
};
```

With these changes we only allow named instanced, like so
```
instance eqBool : Eq Bool {
  Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
  Differ(x, y, k) => and (or x y) (not (and x y)) >> k
};
```

This simplifies the compilation to dictionaries in the future.