### PR TITLE
fix parsing for module names in the cli arguments

### DIFF
--- a/app/Deps.hs
+++ b/app/Deps.hs
@@ -8,16 +8,19 @@ import Pretty.Errors (printLocatedReport)
 import Syntax.CST.Names
 
 
-runDeps :: ModuleName -> IO ()
-runDeps mn = do
-    res <- createDeps mn
-    case res of
-        Left errs -> mapM_ printLocatedReport errs
-        Right (depGraph, compilationOrder) -> do
-            putStrLn "Dependency graph:"
-            printDepGraph depGraph
-            putStrLn "Compilation order:"
-            printCompilationOrder compilationOrder
+runDeps :: Either FilePath ModuleName -> IO ()
+runDeps modId =
+  case modId of
+    Left fp -> putStrLn $ "Please specify module name instead of filepath " ++ fp
+    Right mn -> do
+      res <- createDeps mn
+      case res of
+          Left errs -> mapM_ printLocatedReport errs
+          Right (depGraph, compilationOrder) -> do
+              putStrLn "Dependency graph:"
+              printDepGraph depGraph
+              putStrLn "Compilation order:"
+              printCompilationOrder compilationOrder
 
 createDeps :: ModuleName -> IO (Either (NonEmpty Error) (DepGraph,CompilationOrder))
 createDeps fp =  do 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,10 @@ import Paths_duo_lang (version)
 import Utils (trimStr, filePathToModuleName)
 import GHC.IO.Encoding (setLocaleEncoding)
 import System.IO (utf8)
+import System.Directory (doesFileExist)
+import Parser.Program (moduleNameP)
+import qualified Data.Text as T
+import Parser.Definition (runInteractiveParser)
 
 main :: IO ()
 main = do
@@ -21,15 +25,26 @@ main = do
     opts <- parseOptions
     dispatch opts
 
-filepathToModuleName :: FilePath -> ModuleName
-filepathToModuleName = filePathToModuleName . trimStr 
+-- subcommands requiring a module as argument can accept file paths and module names
+-- this is some preprocessing before passing it to the respective functions
+getModuleName :: String -> IO (Either FilePath ModuleName)
+getModuleName fp = do
+    let fp' = trimStr fp
+    exists <- doesFileExist fp'
+    if exists
+        then pure $ Left fp'
+        else 
+            let mmn = runInteractiveParser moduleNameP $ T.pack fp'
+            in case mmn of
+                 Left _e -> pure $ pure $ filePathToModuleName fp'
+                 Right mn -> pure (pure $ fst mn)
 
 dispatch :: Options -> IO ()
 dispatch (OptLSP log)           = runLSP log
-dispatch (OptRun fp opts)       = runRun opts $ filepathToModuleName fp
-dispatch (OptDeps fp)           = runDeps $ filepathToModuleName fp
+dispatch (OptRun fp opts)       = runRun opts =<< getModuleName fp
+dispatch (OptDeps fp)           = runDeps =<< getModuleName fp
 dispatch OptVersion             = printVersion
-dispatch (OptTypecheck fp opts) = runTypecheck opts $ filepathToModuleName fp
+dispatch (OptTypecheck fp opts) = runTypecheck opts =<< getModuleName fp
 
 printVersion :: IO ()
 printVersion = do

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -29,19 +29,22 @@ desugarEnv MkEnvironment { prdEnv, cnsEnv, cmdEnv } = (prd,cns,cmd)
     cns = (\(tm,_,_) -> tm) <$> cnsEnv
     cmd = fst <$> cmdEnv
 
-runRun :: DebugFlags -> ModuleName -> IO ()
-runRun DebugFlags { df_debug, df_printGraphs } mn = do
-  (res, warnings) <- execDriverM driverState (driverAction mn)
-  mapM_ printLocatedReport warnings
-  case res of
-    Left errs -> mapM_ printLocatedReport errs
-    Right (_, MkDriverState { drvEnv }) -> do
-      -- Run program
-      let compiledEnv :: EvalEnv = focus CBV ((foldMap desugarEnv . M.elems) drvEnv)
-      evalCmd <- liftIO $ eval (TST.Jump defaultLoc (MkFreeVarName "main")) compiledEnv
-      case evalCmd of
-          Left errs -> mapM_ printLocatedReport errs
-          Right _res -> return ()
+runRun :: DebugFlags -> Either FilePath ModuleName -> IO ()
+runRun DebugFlags { df_debug, df_printGraphs } modId = 
+  case modId of
+    Left fp -> putStrLn $ "Please specify module name instead of filepath " ++ fp
+    Right mn -> do
+      (res, warnings) <- execDriverM driverState (driverAction mn)
+      mapM_ printLocatedReport warnings
+      case res of
+        Left errs -> mapM_ printLocatedReport errs
+        Right (_, MkDriverState { drvEnv }) -> do
+          -- Run program
+          let compiledEnv :: EvalEnv = focus CBV ((foldMap desugarEnv . M.elems) drvEnv)
+          evalCmd <- liftIO $ eval (TST.Jump defaultLoc (MkFreeVarName "main")) compiledEnv
+          case evalCmd of
+              Left errs -> mapM_ printLocatedReport errs
+              Right _res -> return ()
     where
       driverState = defaultDriverState { drvOpts = infOpts }
       infOpts = (if df_printGraphs then setPrintGraphOpts else id) infOpts'

--- a/app/Typecheck.hs
+++ b/app/Typecheck.hs
@@ -4,23 +4,41 @@ module Typecheck where
 import Options (DebugFlags(..))
 import Syntax.CST.Names
 import Driver.Driver (runCompilationModule, defaultInferenceOptions)
-import Driver.Definition (defaultDriverState, execDriverM, DriverState(..), setPrintGraphOpts, setDebugOpts)
+import Driver.Definition (defaultDriverState, execDriverM, DriverState(..), setPrintGraphOpts, setDebugOpts, addModule)
 import Pretty.Errors (printLocatedReport)
 import qualified Data.Text as T
 import System.Exit (exitWith, ExitCode (ExitFailure))
 import Data.List (intersperse)
 import Data.Foldable (fold)
+import qualified Data.Text.IO as T
+import Control.Monad.IO.Class (liftIO)
+import Parser.Definition (runFileParser)
+import Syntax.CST.Program (adjustModulePath, Module (..))
+import Parser.Program (moduleP)
+import Control.Monad.Error (throwError)
 
-runTypecheck :: DebugFlags -> ModuleName -> IO ()
-runTypecheck DebugFlags { df_debug, df_printGraphs } mn = do
-  (res,warnings) <- execDriverM driverState $ runCompilationModule mn
+runTypecheck :: DebugFlags -> Either FilePath ModuleName -> IO ()
+runTypecheck DebugFlags { df_debug, df_printGraphs } modId = do
+  (res ,warnings) <- case modId of
+            Left fp -> do
+              file <- liftIO $ T.readFile fp
+              execDriverM driverState $ do
+                mod <- runFileParser fp (moduleP fp) file
+                case adjustModulePath mod fp of
+                  Right mod -> do
+                      let mn = mod_name mod
+                      addModule mod
+                      res <- runCompilationModule mn
+                      pure (mn,res)
+                  Left e -> throwError e
+            Right mn -> execDriverM driverState $ runCompilationModule mn >>= \res -> pure (mn, res)
   mapM_ printLocatedReport warnings
   case res of
     Left errs -> do
       mapM_ printLocatedReport errs
       exitWith (ExitFailure 1)
-    Right (_, MkDriverState {}) -> do
-      putStrLn $ "Module " <> T.unpack (fold (intersperse "." (mn_path mn)) <> "." <> mn_base mn) <> " typechecks"
+    Right ((mn,_), MkDriverState {}) -> do
+      putStrLn $ "Module " <> T.unpack (fold (intersperse "." (mn_path mn ++  [mn_base mn]))) <> " typechecks"
   return ()
     where
       driverState = defaultDriverState { drvOpts = infOpts }

--- a/src/Parser/Program.hs
+++ b/src/Parser/Program.hs
@@ -1,6 +1,7 @@
 module Parser.Program
   ( declarationP
   , moduleP
+  , moduleNameP
   , returnP
   , xtorDeclP
   , xtorSignatureP


### PR DESCRIPTION

using this, `duo check Module.Name` and `duo check path/to/file.duo` should both work correctly.
