### PR TITLE
Add implementation of basic instance resolution

### DIFF
--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -185,8 +185,9 @@ inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, 
     ppPrintIO constraints
     ppPrintIO solverResult
   -- Insert into environment
-  let instty' = TST.instancedecl_typ instanceInferred
-  let f env = env { instanceEnv = M.adjust (S.insert instty') instancedecl_class (instanceEnv env)}
+  let (typ, tyn) = TST.instancedecl_typ instanceInferred
+  let iname = TST.instancedecl_name instanceInferred
+  let f env = env { instanceEnv = M.adjust (S.insert (iname, typ, tyn)) instancedecl_class (instanceEnv env)}
   modifyEnvironment mn f
   pure instanceInferred
 

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -42,7 +42,7 @@ import TypeInference.GenerateConstraints.Kinds
 import TypeInference.GenerateConstraints.Terms
     ( GenConstraints(..),
       genConstraintsTermRecursive )
-import TypeInference.SolveConstraints (solveConstraints)
+import TypeInference.SolveConstraints (solveConstraints, solveClassConstraints)
 import Loc ( Loc, AttachLoc(attachLoc) )
 import Syntax.RST.Types (PolarityRep(..))
 import Syntax.TST.Types qualified as TST
@@ -101,20 +101,23 @@ inferPrdCnsDeclaration mn Core.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcd
   -- 3. Coalesce the result
   let bisubst = coalesce solverResult
   guardVerbose $ ppPrintIO bisubst
-  -- 4. Read of the type and generate the resulting type
+  -- 4. Solve the type class constraints.
+  instances <- liftEitherErrLoc pcdecl_loc $ solveClassConstraints solverResult bisubst env
+  guardVerbose $ ppPrintIO instances
+  -- 5. Read of the type and generate the resulting type
   let typ = TST.zonk TST.UniRep bisubst (TST.getTypeTerm tmInferred)
   guardVerbose $ putStr "\nInferred type: " >> ppPrintIO typ >> putStrLn ""
-  -- 5. Simplify
+  -- 6. Simplify
   typSimplified <- if infOptsSimplify infopts then (do
                      printGraphs <- gets (infOptsPrintGraphs . drvOpts)
                      tys <- simplify (TST.generalize typ) printGraphs (T.unpack (unFreeVarName pcdecl_name))
                      guardVerbose $ putStr "\nInferred type (Simplified): " >> ppPrintIO tys >> putStrLn ""
                      return tys) else return (TST.generalize typ)
-  -- 6. Check type annotation.
+  -- 7. Check type annotation.
   (annotChecked, annotConstrs) <- liftEitherErr $ runGenM pcdecl_loc env (annotateKind pcdecl_annot)
   _ <- liftEitherErrLoc pcdecl_loc $ solveConstraints annotConstrs env
   ty <- checkAnnot (prdCnsToPol pcdecl_pc) typSimplified annotChecked pcdecl_loc
-  -- 7. Insert into environment
+  -- 8. Insert into environment
   case pcdecl_pc of
     PrdRep -> do
       let f env = env { prdEnv  = M.insert pcdecl_name (tmInferred ,pcdecl_loc, case ty of TST.Annotated ty -> ty; TST.Inferred ty -> ty) (prdEnv env) }

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -159,6 +159,12 @@ inferCommandDeclaration mn Core.MkCommandDeclaration { cmddecl_loc, cmddecl_doc,
     ppPrintIO ("" :: T.Text)
     ppPrintIO constraints
     ppPrintIO solverResult
+  -- Coalesce the result
+  let bisubst = coalesce solverResult
+  guardVerbose $ ppPrintIO bisubst
+  -- Solve the type class constraints.
+  instances <- liftEitherErrLoc cmddecl_loc $ solveClassConstraints solverResult bisubst env
+  guardVerbose $ ppPrintIO instances
   -- Insert into environment
   let f env = env { cmdEnv = M.insert cmddecl_name (cmdInferred, cmddecl_loc) (cmdEnv env)}
   modifyEnvironment mn f

--- a/src/Driver/Environment.hs
+++ b/src/Driver/Environment.hs
@@ -23,7 +23,7 @@ data Environment = MkEnvironment
   , cnsEnv :: Map FreeVarName (Term Cns, Loc, TypeScheme Neg)
   , cmdEnv :: Map FreeVarName (Command, Loc)
   , classEnv :: Map ClassName ClassDeclaration
-  , instanceEnv :: Map ClassName (Set (Typ Pos, Typ Neg))
+  , instanceEnv :: Map ClassName (Set (FreeVarName, Typ Pos, Typ Neg))
   , declEnv :: [(Loc,DataDecl)]
   , kindEnv :: Map XtorName (MonoKind, [MonoKind]) -- for each structural constructor a return kind and list of argument kinds
   }

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -37,7 +37,7 @@ instance PrettyAnn ConstraintInfo where
   prettyAnn IntersectionUnionSubConstraint = parens "Intersection/Union"
   prettyAnn RecTypeSubConstraint           = parens "muTypeUnfold"
   prettyAnn NominalSubConstraint           = parens "NominalSubConstraint"
-  prettyAnn ClassResoultionConstraint      = parens "ClassResoultionConstraint"
+  prettyAnn ClassResolutionConstraint      = parens "ClassResolutionConstraint"
 
 
 instance PrettyAnn UVarProvenance where

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -37,6 +37,7 @@ instance PrettyAnn ConstraintInfo where
   prettyAnn IntersectionUnionSubConstraint = parens "Intersection/Union"
   prettyAnn RecTypeSubConstraint           = parens "muTypeUnfold"
   prettyAnn NominalSubConstraint           = parens "NominalSubConstraint"
+  prettyAnn ClassResoultionConstraint      = parens "ClassResoultionConstraint"
 
 
 instance PrettyAnn UVarProvenance where
@@ -47,6 +48,7 @@ instance PrettyAnn UVarProvenance where
   prettyAnn (TypeSchemeInstance fv loc) = parens ("Instantiation of type scheme" <+> prettyAnn fv <+> "at" <+> prettyAnn loc)
   prettyAnn (TypeParameter tn tv) = parens ("Instantiation of type parameter" <+> prettyAnn tv <+> "for" <+> prettyAnn tn)
   prettyAnn (TypeClassInstance cn tv) = parens ("Instantiation for type variable"  <+> prettyAnn tv <+> "of type class" <+> prettyAnn cn)
+  prettyAnn TypeClassResolution = "TypeClassResolution placeholder"
 
 instance (PrettyAnn a) => PrettyAnn (Constraint a) where
   prettyAnn (KindEq ann k1 k2) = 

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -208,8 +208,9 @@ instance PrettyAnn (TST.Bisubstitution TST.RecVT) where
 -- Instance resolution
 ---------------------------------------------------------------------------------
 
-prettyInstanceRes :: (UniTVar, ClassName) -> FreeVarName -> Doc Annotation
-prettyInstanceRes (uv, cn) iname = prettyAnn cn <+> prettyAnn uv <+> "~>" <+> prettyAnn iname
+prettyInstanceRes :: (UniTVar, ClassName) -> (FreeVarName, TST.Typ Pos, TST.Typ Neg) -> Doc Annotation
+prettyInstanceRes (uv, cn) (iname, typ, _tyn) = prettyAnn cn <+> prettyAnn uv <+> "~>"
+                                            <+> prettyAnn iname <+> ":" <+> prettyAnn cn <+> prettyAnn typ
 
 instance PrettyAnn InstanceResult where
   prettyAnn (MkInstanceResult instanceRes) = vsep

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -55,9 +55,7 @@ instance (PrettyAnn a) => PrettyAnn (Constraint a) where
     prettyAnn k1 <+> "~" <+> prettyAnn k2 <+> prettyAnn ann
   prettyAnn (SubType ann t1 t2) =
     prettyAnn t1 <+> "<:" <+> prettyAnn t2 <+> prettyAnn ann
-  prettyAnn (TypeClassPos ann cn typ) =
-    prettyAnn cn <+> prettyAnn typ <+> prettyAnn ann
-  prettyAnn (TypeClassNeg ann cn typ) =
+  prettyAnn (TypeClass ann cn typ) =
     prettyAnn cn <+> prettyAnn typ <+> prettyAnn ann
 
 printUVar :: (UniTVar, UVarProvenance,MonoKind) -> Doc Annotation

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -213,8 +213,12 @@ prettyInstanceRes (uv, cn) (iname, typ, _tyn) = prettyAnn cn <+> prettyAnn uv <+
                                             <+> prettyAnn iname <+> ":" <+> prettyAnn cn <+> prettyAnn typ
 
 instance PrettyAnn InstanceResult where
-  prettyAnn (MkInstanceResult instanceRes) = vsep
-    [ headerise "-" " " "Resolved Instances" 
-    , ""
-    , vsep $ uncurry prettyInstanceRes <$> M.toList instanceRes
-    ]
+  prettyAnn (MkInstanceResult instanceRes) =
+    let instances = M.toList instanceRes
+    in case instances of
+      [] -> mempty
+      _  -> vsep
+              [ headerise "-" " " "Resolved Instances" 
+              , ""
+              , vsep $ uncurry prettyInstanceRes <$> instances
+              ]

--- a/src/Pretty/Constraints.hs
+++ b/src/Pretty/Constraints.hs
@@ -201,3 +201,17 @@ instance PrettyAnn (TST.Bisubstitution TST.RecVT) where
     , vsep $ prettyRecBisubst <$> M.toList (TST.bisubst_map recvsubst)
     ]
 
+
+---------------------------------------------------------------------------------
+-- Instance resolution
+---------------------------------------------------------------------------------
+
+prettyInstanceRes :: (UniTVar, ClassName) -> FreeVarName -> Doc Annotation
+prettyInstanceRes (uv, cn) iname = prettyAnn cn <+> prettyAnn uv <+> "~>" <+> prettyAnn iname
+
+instance PrettyAnn InstanceResult where
+  prettyAnn (MkInstanceResult instanceRes) = vsep
+    [ headerise "-" " " "Resolved Instances" 
+    , ""
+    , vsep $ uncurry prettyInstanceRes <$> M.toList instanceRes
+    ]

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -127,4 +127,4 @@ data SolverResult = MkSolverResult
   }
 
 newtype InstanceResult = MkInstanceResult
-  { instanceResult :: Map (UniTVar, ClassName) FreeVarName }
+  { instanceResult :: Map (UniTVar, ClassName) (FreeVarName, Typ Pos, Typ Neg) }

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -123,3 +123,6 @@ data SolverResult = MkSolverResult
   , kvarSolution    :: Map KVar MonoKind
   , witnessSolution :: Map (Constraint ()) SubtypeWitness
   }
+
+newtype InstanceResult = MkInstanceResult
+  { instanceResult :: Map (UniTVar, ClassName) FreeVarName }

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -42,8 +42,7 @@ data ConstraintInfo
 data Constraint a where
   SubType :: a -> Typ Pos -> Typ Neg -> Constraint a
   KindEq :: a -> MonoKind -> MonoKind -> Constraint a
-  TypeClassPos :: a -> ClassName -> Typ Pos -> Constraint a
-  TypeClassNeg :: a -> ClassName -> Typ Neg -> Constraint a
+  TypeClass :: a -> ClassName -> UniTVar -> Constraint a
     deriving (Eq, Ord, Functor)
 
 -- | Witnesses generated while solving (sub-)constraints.

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -35,6 +35,7 @@ data ConstraintInfo
   | RecTypeSubConstraint
   | NominalSubConstraint
   | KindConstraint
+  | ClassResoultionConstraint
   deriving (Show)
 
 
@@ -96,6 +97,7 @@ data UVarProvenance
   | TypeSchemeInstance FreeVarName Loc     -- ^ UVar generated for the instantiation of a type scheme.
   | TypeParameter RnTypeName SkolemTVar    -- ^ UVar generated for a type parameter of a nominal type
   | TypeClassInstance ClassName SkolemTVar -- ^ UVar generated for a type parameter of a class instance
+  | TypeClassResolution                    -- ^ Placeholder UVar generated during type class resolution.
   
 -- | A ConstraintSet is a set of constraints, together with a list of all the
 -- unification variables occurring in them.

--- a/src/TypeInference/Constraints.hs
+++ b/src/TypeInference/Constraints.hs
@@ -35,7 +35,7 @@ data ConstraintInfo
   | RecTypeSubConstraint
   | NominalSubConstraint
   | KindConstraint
-  | ClassResoultionConstraint
+  | ClassResolutionConstraint
   deriving (Show)
 
 

--- a/src/TypeInference/GenerateConstraints/Definition.hs
+++ b/src/TypeInference/GenerateConstraints/Definition.hs
@@ -188,10 +188,14 @@ createMethodSubst loc decl =
    freshTVars cn ((variance,tv,mk) : vs) = do
     vs' <- freshTVars cn vs
     (tyPos, tyNeg) <- freshTVar (TypeClassInstance cn tv) (Just mk)
-    addConstraint $ case variance of
-       Covariant -> TypeClassPos (InstanceConstraint loc) cn tyPos
-       Contravariant -> TypeClassPos (InstanceConstraint loc) cn tyPos
-    pure ((tyPos, tyNeg) : vs')
+    case tyPos of
+      (TST.TyUniVar _ _ _ uv) -> do
+        addConstraint $ case variance of
+          Covariant -> TypeClass (InstanceConstraint loc) cn uv
+          Contravariant -> TypeClass (InstanceConstraint loc) cn uv
+        pure ((tyPos, tyNeg) : vs')
+      _ -> error "freshTVar should have generated a TyUniVar"
+    
 
 paramsMap :: [(Variance, SkolemTVar, MonoKind)]-> [(TST.Typ Pos, TST.Typ Neg)] -> TST.Bisubstitution TST.SkolemVT
 paramsMap kindArgs freshVars =

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -420,7 +420,7 @@ getInferredType _ _ = throwSolverError defaultLoc [ "UniVar constrained by type 
 trySubtype :: UniTVar -> MonoKind -> Typ Pos -> Typ Neg -> Map ModuleName Environment -> Either (NE.NonEmpty Error) Bool
 trySubtype uv k typ tyn env = do
   let css = [SubType ClassResolutionConstraint typ tyn]
-  let constraintSet = ConstraintSet css [(uv, undefined, k)] []
+  let constraintSet = ConstraintSet css [(uv, TypeClassResolution, k)] []
   catchError
     (True <$ runSolverM (solve css >> runReaderT substitute S.empty) env (createInitState constraintSet))
     (const $ return False)

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -419,7 +419,7 @@ getInferredType _ _ = throwSolverError defaultLoc [ "UniVar constrained by type 
 -- | Try to solve subtyping constraint between two types.
 trySubtype :: UniTVar -> MonoKind -> Typ Pos -> Typ Neg -> Map ModuleName Environment -> Either (NE.NonEmpty Error) Bool
 trySubtype uv k typ tyn env = do
-  let css = [SubType ClassResoultionConstraint typ tyn]
+  let css = [SubType ClassResolutionConstraint typ tyn]
   let constraintSet = ConstraintSet css [(uv, undefined, k)] []
   catchError
     (True <$ runSolverM (solve css >> runReaderT substitute S.empty) env (createInitState constraintSet))

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -142,9 +142,7 @@ solve (cs:css) = do
         addToCache cs (UVarR uv lb)
         newCss <- addLowerBound uv lb
         solve (newCss ++ css)
-      (TypeClassPos _ cn (TyUniVar _ PosRep _ uv)) -> do
-        addTypeClassConstraint uv cn
-      (TypeClassNeg _ cn (TyUniVar _ NegRep _ uv)) -> do
+      (TypeClass _ cn uv) -> do
         addTypeClassConstraint uv cn
       _ -> do
         (w, subCss) <- subConstraints cs
@@ -367,8 +365,7 @@ subConstraints (SubType _ t1 t2) = do
                               , "    " <> ppPrint t2 ]
 -- subConstraints for type classes are deprecated
 -- type class constraints should only be resolved after subtype constraints
-subConstraints TypeClassPos{} = throwSolverError defaultLoc ["subContraints should not be called on type class Constraints"]
-subConstraints TypeClassNeg{} = throwSolverError defaultLoc ["subContraints should not be called on type class Constraints"]
+subConstraints TypeClass{} = throwSolverError defaultLoc ["subContraints should not be called on type class Constraints"]
 subConstraints KindEq{} = throwSolverError defaultLoc ["subContraints should not be called on Kind Equality Constraints"]
 
 -- | Substitute cached witnesses for generated subtyping witness variables.

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -485,5 +485,5 @@ solveClassConstraints sr bisubst env = do
           [] -> throwSolverError defaultLoc [ "No instance in environment defined for " <> ppPrint cn <> " " <> ppPrint uv ]
           [i] -> pure i
           is -> throwSolverError defaultLoc $ ("Incoherent instances resolved for " <> ppPrint cn <> " " <> ppPrint uv)
-                                            : ((\(iname, typ, _tyn) -> ppPrint iname <> " : " <> ppPrint typ) <$> is)
+                                            : ((\(iname, typ, _tyn) -> ppPrint iname <> " : " <> ppPrint cn <> " " <> ppPrint typ) <$> is)
   return (MkInstanceResult (M.fromList res))

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -464,14 +464,14 @@ solveClassConstraints sr bisubst env = do
         ty <- getInferredType typ tyn
         case M.lookup cn instances of
           Nothing -> throwSolverError defaultLoc [ "No instance available for " <> ppPrint cn  ]
-          Just s -> forM (S.toList s) $ \(iname, typ,tyn) -> do
+          Just s -> forM (S.toList s) $ \i@(_iname, typ,tyn) -> do
             case ty of
                Left sub -> do
                 res <- trySubtype uv k sub tyn env
-                if res then pure (Just iname) else pure Nothing
+                if res then pure (Just i) else pure Nothing
                Right sup -> do
                 res <- trySubtype uv k typ sup env
-                if res then pure (Just iname) else pure Nothing
+                if res then pure (Just i) else pure Nothing
   res <- forM res $ \(x, fvs) -> do
     fv <- getJust fvs
     pure (x, fv)

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -430,22 +430,31 @@ trySubtype uv k typ tyn env = do
 
 -- | Try to resolve type class constraint for a UniVar and its lower/upper bounds with given instance environment.
 tryInstances :: UniTVar -> ClassName -> MonoKind -> (Typ 'Pos, Typ 'Neg) -> Map ModuleName Environment
-  -> Either (NE.NonEmpty Error) (FreeVarName, Typ 'Pos, Typ 'Neg)
+             -> Either (NE.NonEmpty Error) (FreeVarName, Typ 'Pos, Typ 'Neg)
 tryInstances uv cn k (typ, tyn) env = do
   ty <- getInferredType typ tyn
   let instances = M.unions $ instanceEnv <$> M.elems env
   case M.lookup cn instances of
           Nothing -> throwSolverError defaultLoc [ "No instance in environment defined for " <> ppPrint cn <> " " <> ppPrint uv ]
-          Just s -> go (S.toList s) ty env
-    where go [] _ _ = throwSolverError defaultLoc [ "No matching instance in environment available for " <> ppPrint cn <> " " <> ppPrint uv ]
+          Just s -> go (S.toList s) ty env []
+    where go :: [(FreeVarName, Typ 'Pos, Typ 'Neg)] -> Either (Typ Pos) (Typ Neg) -> Map ModuleName Environment -> [(FreeVarName, Typ 'Pos, Typ 'Neg)]
+             -> Either (NE.NonEmpty Error) (FreeVarName, Typ 'Pos, Typ 'Neg)
+          go [] (Left sub) _ acc = throwSolverError defaultLoc $
+                                   [ "No matching instance in environment available for " <> ppPrint cn <> " " <> ppPrint sub
+                                   , "Instances checked:" 
+                                   ] ++ ((\(iname, typ, _tyn) -> ppPrint iname <> " : " <> ppPrint typ) <$> acc)
+          go [] (Right sup) _ acc = throwSolverError defaultLoc $
+                                   [ "No matching instance in environment available for " <> ppPrint cn <> " " <> ppPrint sup
+                                   , "Instances checked:" 
+                                   ] ++ ((\(iname, typ, _tyn) -> ppPrint iname <> " : " <> ppPrint typ) <$> acc)
           -- case of covariant type class
-          go (i@(_iname, _typ, tyn):instances) (Left sub) env = do
+          go (i@(_iname, _typ, tyn):instances) (Left sub) env acc = do
             res <- trySubtype uv k sub tyn env
-            if res then pure i else go instances (Left sub) env
+            if res then pure i else go instances (Left sub) env (i : acc)
           -- case of contravariant type class
-          go (i@(_iname, typ, _tyn):instances) (Right sup) env = do
+          go (i@(_iname, typ, _tyn):instances) (Right sup) env acc = do
             res <- trySubtype uv k typ sup env
-            if res then pure i else go instances (Right sup) env
+            if res then pure i else go instances (Right sup) env (i : acc)
 
 
 ------------------------------------------------------------------------------

--- a/std/Class/Eq.duo
+++ b/std/Class/Eq.duo
@@ -15,3 +15,5 @@ instance eqBool : Eq Bool {
   Equals(x, y, k) => or (and x y) (not (or x y)) >> k,
   Differ(x, y, k) => and (or x y) (not (and x y)) >> k
 };
+
+def prd trueIsTrue : Bool := mu k. Equals(True, True, k);

--- a/std/Class/Ord.duo
+++ b/std/Class/Ord.duo
@@ -46,3 +46,6 @@ instance ordBool : Ord Bool {
         }
     } >> k
 };
+
+def prd trueGtFalse : Bool :=
+    mu k. Compare(True, False, case { GT => True >> k, LT => False >> k, EQ => False >> k });

--- a/std/Class/Read.duo
+++ b/std/Class/Read.duo
@@ -16,3 +16,5 @@ instance readBool : Read Bool {
         MkString(f) => False
     } >> k
 };
+
+def cmd readToExit := Read(MkString("True"), case { True => #ExitSuccess, False => #ExitFailure});

--- a/std/Class/Show.duo
+++ b/std/Class/Show.duo
@@ -15,3 +15,5 @@ instance showBool : Show Bool {
         False => MkString("False")
     } >> k
 };
+
+def prd show : String := mu k. Show(True, k);

--- a/test/Counterexamples/CE_059.duo
+++ b/test/Counterexamples/CE_059.duo
@@ -1,0 +1,7 @@
+module CE_059;
+
+-- no instance definition for nominal type
+import Data.Bool;
+
+class Foo(+a : CBV){ Foo(a, return Bool) };
+def prd foo := mu k. Foo(True, k);

--- a/test/Counterexamples/CE_060.duo
+++ b/test/Counterexamples/CE_060.duo
@@ -1,0 +1,9 @@
+module CE_060;
+
+-- no matching instance definition for nominal type
+import Data.Bool;
+import Data.Peano;
+
+class Foo(+a : CBV){ Foo(a, return Bool) };
+instance foo : Foo Bool { Foo(x, k) => x >> k };
+def prd bar := mu k. Foo(Z, k);

--- a/test/Counterexamples/CE_061.duo
+++ b/test/Counterexamples/CE_061.duo
@@ -5,5 +5,5 @@ import Data.Bool;
 
 class Foo(+a : CBV){ Foo(a, return Bool) };
 instance foo : Foo Bool { Foo(x, k) => x >> k };
-instance bar : Foo Bool { Foo(x, k) => x >> k };
+instance bar : Foo Bool { Foo(x, k) => not x >> k };
 def prd baz := mu k. Foo(False, k);

--- a/test/Counterexamples/CE_061.duo
+++ b/test/Counterexamples/CE_061.duo
@@ -1,0 +1,9 @@
+module CE_061;
+
+-- incoherent instances
+import Data.Bool;
+
+class Foo(+a : CBV){ Foo(a, return Bool) };
+instance foo : Foo Bool { Foo(x, k) => x >> k };
+instance bar : Foo Bool { Foo(x, k) => x >> k };
+def prd baz := mu k. Foo(False, k);

--- a/test/Spec/TypeInferenceExamples.hs
+++ b/test/Spec/TypeInferenceExamples.hs
@@ -8,14 +8,13 @@ import Data.Either( isRight, isLeft )
 import Syntax.TST.Program qualified as TST
 import Syntax.CST.Program qualified as CST
 import Errors
-import Utils (moduleNameToFullPath, filePathToModuleName)
+import Utils (moduleNameToFullPath)
 import Syntax.CST.Names (ModuleName)
 
 type Reason = String
 
 pendingFiles :: [(ModuleName, Reason)]
-pendingFiles = [ (filePathToModuleName "CE_053", "Constraint Solver for type class methods not implemented yet.")
-               ]
+pendingFiles = []
 
 -- | Typecheck the programs in the toplevel "examples/" subfolder.
 spec :: [((FilePath, ModuleName), Either (NonEmpty Error) CST.Module)]


### PR DESCRIPTION
These changes allow us to resolve instances for type class methods in producer and consumer declarations.
The debugging output shows which instance has been resolved for each type class constraint.

E.g. in
```
module Class.Show;

import Prim.Strings;
import Data.Bool;

-- | Definition for type class of showable types.
class Show(+a : CBV){
    Show(a, return String)
};

-- | Convert a Boolean constructor to its /String/ representation.
instance showBool : Show Bool {
    Show(b, k) => case b of {
        True => MkString("True"),
        False => MkString("False")
    } >> k
};

def prd show : String := mu k. Show(True, k);
```

the output is:

```
------------------------------------------------------------
                     Resolved Instances                     
------------------------------------------------------------

Show u1 ~> showBool : Show Bool
```

With this PR #462 can be closed.