### PR TITLE
Type Inference now only uses annotated Kind when it is needed

### DIFF
--- a/examples/KindAnnotations.duo
+++ b/examples/KindAnnotations.duo
@@ -1,9 +1,13 @@
 module KindAnnotations;
 
 import Codata.Function;
+import Data.Peano;
 
 -- here a is annotated as CBV
 def prd idAnnotRight : forall (a : CBV). a -> a :=
   \x => x;
 
 def prd floatAnnot : (#F64:F64Rep) := 1.0#F64;
+
+def rec prd annotWithKind : (Nat:CBV) := annotWithKind;
+def rec prd annotNoKind : Nat := annotNoKind;

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -74,7 +74,7 @@ checkAnnot _ tyInferred Nothing _ = return (TST.Inferred tyInferred)
 checkAnnot rep tyInferred (Just tyAnnotated) loc = do
   env <- gets drvEnv
   (annotChecked, annotConstrs) <- liftEitherErr $ runGenM loc env (annotateKind tyAnnotated)
-  solverResAnnot <- liftEitherErrLoc loc $ solveConstraints annotConstrs env
+  solverResAnnot <- liftEitherErrLoc loc $ solveConstraints annotConstrs Nothing env 
   let bisubstAnnot = coalesce solverResAnnot
   let typAnnotZonked = TST.zonk TST.UniRep bisubstAnnot annotChecked
   let isSubsumed = subsume rep tyInferred typAnnotZonked
@@ -114,7 +114,7 @@ inferPrdCnsDeclaration mn Core.MkPrdCnsDeclaration { pcdecl_loc, pcdecl_doc, pcd
     ppPrintIO ("" :: T.Text)
     ppPrintIO constraintSetModified
   -- 2. Solve the constraints.
-  solverResult <- liftEitherErrLoc pcdecl_loc $ solveConstraints constraintSetModified env
+  solverResult <- liftEitherErrLoc pcdecl_loc $ solveConstraints constraintSetModified Nothing env
   guardVerbose $ ppPrintIO solverResult
   -- 3. Coalesce the result
   let bisubst = coalesce solverResult
@@ -168,7 +168,7 @@ inferCommandDeclaration mn Core.MkCommandDeclaration { cmddecl_loc, cmddecl_doc,
   -- Generate the constraints
   (cmdInferred,constraints) <- liftEitherErr (runGenM cmddecl_loc env (genConstraints cmddecl_cmd))
   -- Solve the constraints
-  solverResult <- liftEitherErrLoc cmddecl_loc $ solveConstraints constraints env
+  solverResult <- liftEitherErrLoc cmddecl_loc $ solveConstraints constraints Nothing env
   guardVerbose $ do
     ppPrintIO (Header (unFreeVarName cmddecl_name))
     ppPrintIO ("" :: T.Text)
@@ -200,7 +200,7 @@ inferInstanceDeclaration mn decl@Core.MkInstanceDeclaration { instancedecl_loc, 
   -- Generate the constraints
   (instanceInferred,constraints) <- liftEitherErr (runGenM instancedecl_loc env (genConstraints decl))
   -- Solve the constraints
-  solverResult <- liftEitherErrLoc instancedecl_loc $ solveConstraints constraints env
+  solverResult <- liftEitherErrLoc instancedecl_loc $ solveConstraints constraints Nothing env
   guardVerbose $ do
     ppPrintIO (Header  $ unClassName instancedecl_class <> " " <> ppPrint (fst instancedecl_typ))
     ppPrintIO ("" :: T.Text)

--- a/src/TypeInference/GenerateConstraints/Definition.hs
+++ b/src/TypeInference/GenerateConstraints/Definition.hs
@@ -32,7 +32,6 @@ module TypeInference.GenerateConstraints.Definition
   , GenerateState(..)
   , initialState
   , initialReader
-  , addKindAnnotConstr
 ) where
 
 
@@ -81,10 +80,6 @@ initialConstraintSet =
                 , cs_uvars = []
                 , cs_kvars = []
                 }
-
-addKindAnnotConstr :: MonoKind -> MonoKind -> ConstraintSet -> ConstraintSet 
-addKindAnnotConstr mk mk' cs@ConstraintSet { cs_constraints } = 
-  cs { cs_constraints = (KindEq KindConstraint mk mk'):cs_constraints }
 
 initialState :: GenerateState
 initialState = GenerateState {   uVarCount = 0

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -476,7 +476,7 @@ zonkVariableState m (VariableState lbs ubs tc k) = do
   VariableState zonkedlbs zonkedubs tc zonkedKind
 
 -- | Creates the variable states that results from solving constraints.
-solveConstraints :: ConstraintSet -> Maybe MonoKind -> Map ModuleName Environment -> Either (NE.NonEmpty Error) SolverResult
+solveConstraints :: ConstraintSet -> Maybe (KVar, MonoKind) -> Map ModuleName Environment -> Either (NE.NonEmpty Error) SolverResult
 solveConstraints constraintSet@(ConstraintSet css _ _) annotKind env = do
   (_, solverState) <- runSolverM (solve css >> runReaderT substitute S.empty) env (createInitState constraintSet)
   kvarSolution <- computeKVarSolution ErrorUnresolved (sst_kvars solverState)

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -476,8 +476,8 @@ zonkVariableState m (VariableState lbs ubs tc k) = do
   VariableState zonkedlbs zonkedubs tc zonkedKind
 
 -- | Creates the variable states that results from solving constraints.
-solveConstraints :: ConstraintSet -> Map ModuleName Environment ->  Either (NE.NonEmpty Error) SolverResult
-solveConstraints constraintSet@(ConstraintSet css _ _) env = do
+solveConstraints :: ConstraintSet -> Maybe MonoKind -> Map ModuleName Environment -> Either (NE.NonEmpty Error) SolverResult
+solveConstraints constraintSet@(ConstraintSet css _ _) annotKind env = do
   (_, solverState) <- runSolverM (solve css >> runReaderT substitute S.empty) env (createInitState constraintSet)
   kvarSolution <- computeKVarSolution ErrorUnresolved (sst_kvars solverState)
   let tvarSol = zonkVariableState kvarSolution <$> sst_bounds solverState


### PR DESCRIPTION
This PR changes constraint solving to optionally take a (KVar, MonoKind) that is used if after constraint solving the given kind var has no assigned kind.
This means that now Kind Annotations are no longer needed when the kind is clear from the annotation, but if the annotation is wrong it will still be detected from the subsumption test (see new example in KindAnnotations.duo).

It will also simplify adding polykinds to types, as otherwise it always needs to be checked for type annotations (like with Nominal Types so far).

Based on the fix in #526
