### PR TITLE
Resolve annotated instances based on type class variance

### DIFF
--- a/src/Resolution/Terms.hs
+++ b/src/Resolution/Terms.hs
@@ -263,11 +263,8 @@ resolveCommand (CST.Xtor loc xtor ty arity) = do
           ExplicitSubst es -> return (map snd es)
           ImplicitSubst {} ->  throwOtherError loc ["The substitution in a method call cannot contain implicit arguments"]
       pctms <- resolveTerms loc ar subst'
-      ty' <- case ty of Nothing -> pure Nothing; Just ty -> Just <$> do
-                            typ <- resolveTyp PosRep ty
-                            tyn <- resolveTyp NegRep ty
-                            pure (typ, tyn)
-      pure $! RST.Method loc mn cn ty' (RST.MkSubstitution pctms)
+      ty' <- mapM (\ty' -> resolveTyp PosRep ty' >>= \typ -> resolveTyp NegRep ty' >>= \tyn -> pure (typ, tyn)) ty
+      pure $ RST.Method loc mn cn ty' (RST.MkSubstitution pctms)
 ---------------------------------------------------------------------------------
 -- CST constructs which can only be resolved to commands
 ---------------------------------------------------------------------------------

--- a/src/Resolution/Types.hs
+++ b/src/Resolution/Types.hs
@@ -9,7 +9,6 @@ import Control.Monad.Except (throwError)
 import Data.Set qualified as S
 import Data.List.NonEmpty (NonEmpty((:|)))
 import Data.List.NonEmpty qualified as NE
-import Data.Text qualified as T
 
 import Errors
 import Pretty.Pretty

--- a/src/Translate/EmbedTST.hs
+++ b/src/Translate/EmbedTST.hs
@@ -12,8 +12,7 @@ import Syntax.Core.Terms qualified as Core
 import Syntax.Core.Program qualified as Core
 
 import Data.Bifunctor (bimap, second)
-import Data.List.NonEmpty (NonEmpty((:|)))
-import Syntax.CST.Kinds (PolyKind(..), MonoKind(..), EvaluationOrder(..))
+import Syntax.CST.Kinds (PolyKind(..), MonoKind(..))
 
 ---------------------------------------------------------------------------------
 -- A typeclass for embedding TST.X into Core.X


### PR DESCRIPTION
With this fix we no longer brute-force resolve instances but use the variance information to only look for either sub- or supertypes of the annotated type.