### PR TITLE
update stack snapshot

### DIFF
--- a/app/LSP/LSP.hs
+++ b/app/LSP/LSP.hs
@@ -90,7 +90,7 @@ handlers = mconcat [ initializedHandler
 
 runLSP :: Maybe FilePath -> IO ()
 runLSP mLogPath = do
-  LSP.setupLogger mLogPath ["lspserver"] DEBUG
+  --  LSP.setupLogger mLogPath ["lspserver"] DEBUG
   debugM "lspserver" "Starting LSP Server"
   initialDefinition <- definition
   errCode <- LSP.runServer initialDefinition

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-19.22
+resolver: lts-20.7
 
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,24 +7,24 @@ packages:
 - completed:
     hackage: diagnose-2.2.0@sha256:0909bf51e296a484f34a4bc35ee84f349602bde0e2083c7659d7e38f258a2453,5941
     pantry-tree:
-      size: 1402
       sha256: 6c45647f171dbf96c5cd2dbf9af6c9ba8cac5408968a3504c1464fe7895c0904
+      size: 1402
   original:
     hackage: diagnose-2.2.0
 - completed:
+    commit: 747297319f0dd0c8e8f72b7de4fbf52aad73d5b0
+    git: https://github.com/solidsnack/wcwidth.git
     name: wcwidth
-    version: 0.0.2
-    git: https://github.com/solidsnack/wcwidth.git
     pantry-tree:
-      size: 815
       sha256: dc6939beb9b35fcebebfe22eef013d9438ff2dd885b517fb7ea352dee4d580a7
-    commit: 747297319f0dd0c8e8f72b7de4fbf52aad73d5b0
+      size: 815
+    version: 0.0.2
   original:
-    git: https://github.com/solidsnack/wcwidth.git
     commit: 747297319f0dd0c8e8f72b7de4fbf52aad73d5b0
+    git: https://github.com/solidsnack/wcwidth.git
 snapshots:
 - completed:
-    size: 619399
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/22.yaml
-    sha256: 5098594e71bdefe0c13e9e6236f12e3414ef91a2b89b029fd30e8fc8087f3a07
-  original: lts-19.22
+    sha256: 8bcce0b4f5671ea04691477f5af759b497b8892f998768d6eb01c64c58d41d7c
+    size: 649329
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/7.yaml
+  original: lts-20.7


### PR DESCRIPTION
Update to a more recent LTS snapshot

This changed the LSP version (from 1.4 to 1.6).
There is one small issue with migration of this package, cf.
https://github.com/haskell/lsp/issues/441

I don't know if just removing the logging line is all that is needed (if we want to keep logging), but it works again now.
