### PR TITLE
Refactor type parser

### DIFF
--- a/src/Parser/Types.hs
+++ b/src/Parser/Types.hs
@@ -91,7 +91,7 @@ nominalTypeP = do
 ---------------------------------------------------------------------------------
 
 refinementArgsP :: Parser (Maybe (TypeName, Maybe SkolemTVar))
-refinementArgsP = optional $ do
+refinementArgsP = optional $ try $ do
   (tn,_) <- typeNameP
   sc
   symbolP SymPipe


### PR DESCRIPTION
The parsers for structural and refinement types have been combined, and the `try` has been moved inside. I.e. the parser will no longer backtrack once it has succesfully read an opening `{` or `<`.