### PR TITLE
Move Driver.Environment to TypeInference.Environment

### DIFF
--- a/app/Run.hs
+++ b/app/Run.hs
@@ -4,7 +4,7 @@ import Control.Monad.IO.Class (liftIO)
 import Data.Map qualified as M
 
 import Driver.Definition
-import Driver.Environment
+import TypeInference.Environment
 import Driver.Driver ( runCompilationModule )
 import Eval.Definition (EvalEnv)
 import Eval.Eval (eval)

--- a/duo-lang.cabal
+++ b/duo-lang.cabal
@@ -112,7 +112,6 @@ library
       Driver.Definition
       Driver.DepGraph
       Driver.Driver
-      Driver.Environment
       Errors
       Eval.Definition
       Eval.Eval
@@ -148,6 +147,7 @@ library
       TypeInference.GenerateConstraints.Primitives
       TypeInference.GenerateConstraints.Terms
       TypeInference.GenerateConstraints.Kinds
+      TypeInference.Environment
       TypeInference.SolveConstraints
       TypeInference.Constraints
       Translate.Focusing

--- a/src/Driver/Definition.hs
+++ b/src/Driver/Definition.hs
@@ -9,7 +9,7 @@ import Data.Text qualified as T
 import System.Directory ( makeAbsolute )
 
 
-import Driver.Environment ( Environment, emptyEnvironment )
+import TypeInference.Environment ( Environment, emptyEnvironment )
 import Errors
 import Errors.Renamer
 import Pretty.Pretty

--- a/src/Driver/Driver.hs
+++ b/src/Driver/Driver.hs
@@ -20,7 +20,7 @@ import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Driver.Definition
-import Driver.Environment
+import TypeInference.Environment
 import Driver.DepGraph
 import Errors
 import Errors.Renamer

--- a/src/Pretty/Program.hs
+++ b/src/Pretty/Program.hs
@@ -4,7 +4,7 @@ import Data.List (intersperse)
 import Data.Map qualified as M
 import Prettyprinter
 
-import Driver.Environment
+import TypeInference.Environment
 import Pretty.Pretty
 import Pretty.Terms ()
 import Pretty.Types ()

--- a/src/TypeInference/Environment.hs
+++ b/src/TypeInference/Environment.hs
@@ -1,4 +1,4 @@
-module Driver.Environment where
+module TypeInference.Environment where
 
 import Control.Monad.Except
 import Control.Monad.Reader

--- a/src/TypeInference/GenerateConstraints/Definition.hs
+++ b/src/TypeInference/GenerateConstraints/Definition.hs
@@ -44,7 +44,7 @@ import Data.Map ( Map )
 import Data.Map qualified as M
 import Data.Text qualified as T
 
-import Driver.Environment
+import TypeInference.Environment
 import Errors
 import Errors.Renamer
 import Syntax.RST.Types qualified as RST

--- a/src/TypeInference/GenerateConstraints/Kinds.hs
+++ b/src/TypeInference/GenerateConstraints/Kinds.hs
@@ -18,7 +18,7 @@ import Errors
 import Loc
 import TypeInference.Constraints
 import TypeInference.GenerateConstraints.Definition
-import Driver.Environment
+import TypeInference.Environment
 
 import Control.Monad.Reader
 import Control.Monad.Except

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -24,7 +24,7 @@ import TypeInference.GenerateConstraints.Kinds
 import TypeInference.Constraints
 import TypeInference.SolveConstraints (resolveInstanceAnnot)
 import Loc
-import Driver.Environment
+import TypeInference.Environment
 import TypeInference.GenerateConstraints.Primitives (primOps)
 import Syntax.RST.Program (ClassDeclaration(classdecl_kinds))
 import Syntax.TST.Terms (Substitution(..))

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -19,7 +19,7 @@ import Data.Set (Set)
 import Data.Set qualified as S
 import Data.List (partition)
 
-import Driver.Environment (Environment (..))
+import TypeInference.Environment (Environment (..))
 import Errors
 import Syntax.TST.Types
 import Syntax.RST.Types (PolarityRep(..), Polarity(..))


### PR DESCRIPTION
I want to turn constraint generation into its submodule, but for this to work the Environment should be in the namespace of TypeInference, not the driver.