### PR TITLE
Rec var refactor

### DIFF
--- a/app/LSP/Handler/Hover.hs
+++ b/app/LSP/Handler/Hover.hs
@@ -329,7 +329,7 @@ instance ToHoverMap (TST.Typ pol) where
                       ]
     in
       M.unions (mkHoverMap loc msg : (toHoverMap <$> xtors))
-  toHoverMap (TST.TyDataRefined loc rep _knd tn _ xtors) =
+  toHoverMap (TST.TyDataRefined loc rep _knd tn xtors) =
     let
       msg = T.unlines [ "#### Refinement datatype"
                       , "- Name: `" <> ppPrint tn <> "`"
@@ -346,7 +346,7 @@ instance ToHoverMap (TST.Typ pol) where
                       ]
     in
       M.unions (mkHoverMap loc msg : (toHoverMap <$> xtors))
-  toHoverMap (TST.TyCodataRefined loc rep _knd tn _ xtors) =
+  toHoverMap (TST.TyCodataRefined loc rep _knd tn xtors) =
     let
       msg = T.unlines [ "#### Refinement codata type"
                       , "- Name: `" <> ppPrint tn <> "`"

--- a/app/LSP/Handler/JumpToDef.hs
+++ b/app/LSP/Handler/JumpToDef.hs
@@ -149,11 +149,11 @@ instance ToJumpMap (RST.Typ pol) where
     M.empty
   toJumpMap RST.TyRecVar {} = 
     M.empty
-  toJumpMap (RST.TyDataRefined loc _ _ tn _ xtors) =
+  toJumpMap (RST.TyDataRefined loc _ _ tn xtors) =
     M.unions (M.fromList [(locToRange loc, toLocation tn)] : (toJumpMap <$> xtors))
   toJumpMap (RST.TyData _ _ xtors) =
     M.unions (toJumpMap <$> xtors)
-  toJumpMap (RST.TyCodataRefined loc _ _ tn _ xtors) =
+  toJumpMap (RST.TyCodataRefined loc _ _ tn xtors) =
     M.unions (M.fromList [(locToRange loc, toLocation tn)] : (toJumpMap <$> xtors))
   toJumpMap (RST.TyCodata _ _ xtors) =
     M.unions (toJumpMap <$> xtors)

--- a/duo-lang-parser/src/Parser/Types.hs
+++ b/duo-lang-parser/src/Parser/Types.hs
@@ -105,7 +105,9 @@ xdataOrRefinementP Data = do
   sc
   case refinementargs of
     Nothing -> pure (TyXData (Loc startPos endPos) Data ctors, endPos)
-    Just (tn, rv) ->  pure (TyXRefined (Loc startPos endPos) Data tn rv ctors, endPos)
+    Just (tn, Nothing) -> pure (TyXRefined (Loc startPos endPos) Data tn ctors, endPos)
+    Just (tn, Just rv) -> pure (TyRec (Loc startPos endPos) rv (TyXRefined (Loc startPos endPos) Data tn ctors),endPos)
+
 xdataOrRefinementP Codata = do
   startPos <- getSourcePos
   symbolP SymBraceLeft
@@ -117,7 +119,8 @@ xdataOrRefinementP Codata = do
   sc
   case refinementargs of
     Nothing -> pure (TyXData (Loc startPos endPos) Codata dtors, endPos)
-    Just (tn, rv) -> pure (TyXRefined (Loc startPos endPos) Codata tn rv dtors, endPos)
+    Just (tn, Nothing) -> pure (TyXRefined (Loc startPos endPos) Codata tn dtors, endPos)
+    Just (tn, Just rv) -> pure (TyRec (Loc startPos endPos) rv (TyXRefined (Loc startPos endPos) Codata tn dtors), endPos)
 
 
 ---------------------------------------------------------------------------------

--- a/duo-lang-parser/src/Syntax/CST/Types.hs
+++ b/duo-lang-parser/src/Syntax/CST/Types.hs
@@ -34,7 +34,7 @@ data Typ where
   TyUniVar :: Loc -> UniTVar -> Typ
   TySkolemVar :: Loc -> SkolemTVar -> Typ
   TyXData    :: Loc -> DataCodata             -> [XtorSig] -> Typ
-  TyXRefined :: Loc -> DataCodata -> TypeName -> Maybe SkolemTVar -> [XtorSig] -> Typ
+  TyXRefined :: Loc -> DataCodata -> TypeName -> [XtorSig] -> Typ
   TyNominal :: Loc -> TypeName -> Typ
   TyApp :: Loc -> Typ -> NonEmpty Typ -> Typ
   TyRec :: Loc -> SkolemTVar -> Typ -> Typ
@@ -59,7 +59,7 @@ instance HasLoc Typ where
   getLoc (TyUniVar loc _) = loc
   getLoc (TySkolemVar loc _) = loc
   getLoc (TyXData loc _ _) = loc
-  getLoc (TyXRefined loc _ _ _ _) = loc
+  getLoc (TyXRefined loc _ _ _) = loc
   getLoc (TyNominal loc _ ) = loc
   getLoc (TyApp loc _ _) = loc
   getLoc (TyRec loc _ _) = loc

--- a/duo-lang-renamer/src/Resolution/Program.hs
+++ b/duo-lang-renamer/src/Resolution/Program.hs
@@ -56,7 +56,7 @@ checkVarianceTyp loc var polyKind (CST.TyXData _loc' dataCodata  xtorSigs) = do
                       CST.Data   -> Covariant
                       CST.Codata -> Contravariant
   sequence_ $ checkVarianceXtor loc var' polyKind <$> xtorSigs
-checkVarianceTyp loc var polyKind (CST.TyXRefined _loc' dataCodata  _tn _ xtorSigs) = do
+checkVarianceTyp loc var polyKind (CST.TyXRefined _loc' dataCodata  _tn xtorSigs) = do
   let var' = var <> case dataCodata of
                       CST.Data   -> Covariant
                       CST.Codata -> Contravariant

--- a/duo-lang-renamer/src/Resolution/SymbolTable.hs
+++ b/duo-lang-renamer/src/Resolution/SymbolTable.hs
@@ -213,5 +213,5 @@ isPermittedInstance :: ClassName -> Typ -> SymbolTable -> Bool
 isPermittedInstance cn ty st = S.member cn st.classDecls || maybe False (`M.member` st.typeNameMap) (getTypeName ty)
   where getTypeName :: Typ -> Maybe TypeName
         getTypeName (TyNominal _ typeName) = Just typeName
-        getTypeName (TyXRefined _ _ typeName _ _) = Just typeName
+        getTypeName (TyXRefined _ _ typeName _ ) = Just typeName
         getTypeName _ = Nothing

--- a/duo-lang-renamer/src/Resolution/Types.hs
+++ b/duo-lang-renamer/src/Resolution/Types.hs
@@ -53,7 +53,7 @@ resolveTyp rep (TyXData loc Data sigs) = do
 resolveTyp rep (TyXRefined loc Data tn sigs) = do
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
     sigs <- resolveXTorSigs rep sigs
-    pure $ RST.TyDataRefined loc rep pknd tn' Nothing sigs
+    pure $ RST.TyDataRefined loc rep pknd tn' sigs
 -- Nominal Codata
 resolveTyp rep (TyXData loc Codata sigs) = do
     sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
@@ -62,7 +62,7 @@ resolveTyp rep (TyXData loc Codata sigs) = do
 resolveTyp rep (TyXRefined loc Codata tn sigs) = do
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
     sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
-    pure $ RST.TyCodataRefined loc rep pknd tn' Nothing sigs
+    pure $ RST.TyCodataRefined loc rep pknd tn' sigs
 resolveTyp rep (TyNominal loc name) = do
   res <- lookupTypeConstructor loc name
   case res of 
@@ -102,14 +102,14 @@ resolveTyp rep (TyApp loc (TyXRefined loc' Data tn sigs) args) = do
     sigs <- resolveXTorSigs rep sigs
     args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
     let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
-    pure $ RST.TyApp loc rep (RST.TyDataRefined loc' rep pknd tn' Nothing sigs) args''
+    pure $ RST.TyApp loc rep (RST.TyDataRefined loc' rep pknd tn' sigs) args''
 
 resolveTyp rep (TyApp loc (TyXRefined loc' Codata tn sigs) args) = do 
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
     sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
     args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
     let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
-    pure $ RST.TyApp loc rep (RST.TyCodataRefined loc' rep pknd tn' Nothing sigs) args''
+    pure $ RST.TyApp loc rep (RST.TyCodataRefined loc' rep pknd tn' sigs) args''
 
   
 resolveTyp rep (TyApp loc (TyKindAnnot mk ty) args) = do 

--- a/duo-lang-renamer/src/Resolution/Types.hs
+++ b/duo-lang-renamer/src/Resolution/Types.hs
@@ -50,28 +50,19 @@ resolveTyp rep (TyXData loc Data sigs) = do
     sigs <- resolveXTorSigs rep sigs
     pure $ RST.TyData loc rep sigs
 -- Refinement Data
-resolveTyp rep (TyXRefined loc Data tn mrv sigs) = do
+resolveTyp rep (TyXRefined loc Data tn sigs) = do
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
-    if not (null pknd.kindArgs) then throwError (UnknownResolutionError loc ("Type " <> T.pack (show tn) <> " was not fully applied"))
-    else do
-      case mrv of 
-        Nothing -> do
-          sigs <- resolveXTorSigs rep sigs
-          pure $ RST.TyDataRefined loc rep pknd tn' Nothing sigs
-        Just sk -> do
-          let rv = skolemToRecRVar sk
-          sigs <- local (\r -> r { rr_recVars = S.insert rv r.rr_recVars } ) $ resolveXTorSigs rep sigs
-          return $ RST.TyDataRefined loc rep pknd tn' (Just rv) sigs 
+    sigs <- resolveXTorSigs rep sigs
+    pure $ RST.TyDataRefined loc rep pknd tn' Nothing sigs
 -- Nominal Codata
 resolveTyp rep (TyXData loc Codata sigs) = do
     sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
     pure $ RST.TyCodata loc rep sigs
 -- Refinement Codata
-resolveTyp rep (TyXRefined loc Codata tn mrv sigs) = do
+resolveTyp rep (TyXRefined loc Codata tn sigs) = do
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
     sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
-    let rv = skolemToRecRVar <$> mrv
-    pure $ RST.TyCodataRefined loc rep pknd tn' rv sigs
+    pure $ RST.TyCodataRefined loc rep pknd tn' Nothing sigs
 resolveTyp rep (TyNominal loc name) = do
   res <- lookupTypeConstructor loc name
   case res of 
@@ -106,36 +97,19 @@ resolveTyp rep (TyApp loc (TySkolemVar loc' sk) args) = do
       let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst :| rst
       pure $ RST.TyApp loc rep (RST.TyRecVar loc' rep rv) args''
 
-resolveTyp rep (TyApp loc (TyXRefined loc' Data tn mrv sigs) args) = do 
+resolveTyp rep (TyApp loc (TyXRefined loc' Data tn sigs) args) = do 
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
-    case mrv of 
-      Nothing -> do
-        sigs <- resolveXTorSigs rep sigs
-        args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
-        let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
-        pure $ RST.TyApp loc rep (RST.TyDataRefined loc' rep pknd tn' Nothing sigs) args''
-      Just sk -> do 
-        let rv = skolemToRecRVar sk
-        sigs <- local (\r -> r { rr_ref_recVars = M.insert rv (tn,pknd) r.rr_ref_recVars  } ) $ resolveXTorSigs rep sigs
-        args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
-        let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
-        return $ RST.TyApp loc rep (RST.TyDataRefined loc' rep pknd tn' (Just rv) sigs) args''
+    sigs <- resolveXTorSigs rep sigs
+    args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
+    let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
+    pure $ RST.TyApp loc rep (RST.TyDataRefined loc' rep pknd tn' Nothing sigs) args''
 
-resolveTyp rep (TyApp loc (TyXRefined loc' Codata tn mrv sigs) args) = do 
+resolveTyp rep (TyApp loc (TyXRefined loc' Codata tn sigs) args) = do 
     NominalResult tn' _ _ pknd <- lookupTypeConstructor loc tn
-    case mrv of 
-      Nothing -> do
-        sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
-        args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
-        let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
-        pure $ RST.TyApp loc rep (RST.TyCodataRefined loc' rep pknd tn' Nothing sigs) args''
-      Just sk -> do 
-        let rv = skolemToRecRVar sk
-        sigs <- local (\r -> r { rr_ref_recVars = M.insert rv (tn,pknd) r.rr_ref_recVars } ) $ resolveXTorSigs (flipPolarityRep rep) sigs
-        args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
-        let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
-        return $ RST.TyApp loc rep (RST.TyCodataRefined loc' rep pknd tn' (Just rv) sigs) args''
-
+    sigs <- resolveXTorSigs (flipPolarityRep rep) sigs
+    args' <- resolveTypeArgs loc rep tn pknd (NE.toList args)
+    let args'' = case args' of [] -> error "can't happen"; (fst:rst) -> fst:|rst
+    pure $ RST.TyApp loc rep (RST.TyCodataRefined loc' rep pknd tn' Nothing sigs) args''
 
   
 resolveTyp rep (TyApp loc (TyKindAnnot mk ty) args) = do 

--- a/duo-lang-renamer/src/Resolution/Unresolve.hs
+++ b/duo-lang-renamer/src/Resolution/Unresolve.hs
@@ -579,14 +579,12 @@ instance Unresolve (RST.Typ pol) CST.Typ where
   unresolve (RST.TyCodata loc _ xtors) = do
     xtors' <- mapM unresolve xtors
     pure $ CST.TyXData loc CST.Codata xtors'
-  unresolve (RST.TyDataRefined loc _ _ tn mrv xtors) = do
+  unresolve (RST.TyDataRefined loc _ _ tn _ xtors) = do
     xtors' <- mapM unresolve xtors
-    let rv = fmap embedRecTVar mrv
-    pure $ CST.TyXRefined loc CST.Data tn.rnTnName rv xtors'
-  unresolve (RST.TyCodataRefined loc _ _ tn mrv xtors) = do
+    pure $ CST.TyXRefined loc CST.Data tn.rnTnName xtors'
+  unresolve (RST.TyCodataRefined loc _ _ tn _ xtors) = do
     xtors' <- mapM unresolve xtors
-    let rv = fmap embedRecTVar mrv
-    pure $ CST.TyXRefined loc CST.Codata tn.rnTnName rv xtors'
+    pure $ CST.TyXRefined loc CST.Codata tn.rnTnName xtors'
   unresolve (RST.TyApp loc _ ty args) = do 
     ty' <- unresolve ty
     args' <- mapM unresolve args

--- a/duo-lang-renamer/src/Resolution/Unresolve.hs
+++ b/duo-lang-renamer/src/Resolution/Unresolve.hs
@@ -579,10 +579,10 @@ instance Unresolve (RST.Typ pol) CST.Typ where
   unresolve (RST.TyCodata loc _ xtors) = do
     xtors' <- mapM unresolve xtors
     pure $ CST.TyXData loc CST.Codata xtors'
-  unresolve (RST.TyDataRefined loc _ _ tn _ xtors) = do
+  unresolve (RST.TyDataRefined loc _ _ tn xtors) = do
     xtors' <- mapM unresolve xtors
     pure $ CST.TyXRefined loc CST.Data tn.rnTnName xtors'
-  unresolve (RST.TyCodataRefined loc _ _ tn _ xtors) = do
+  unresolve (RST.TyCodataRefined loc _ _ tn xtors) = do
     xtors' <- mapM unresolve xtors
     pure $ CST.TyXRefined loc CST.Codata tn.rnTnName xtors'
   unresolve (RST.TyApp loc _ ty args) = do 

--- a/duo-lang-renamer/src/Syntax/RST/Types.hs
+++ b/duo-lang-renamer/src/Syntax/RST/Types.hs
@@ -131,8 +131,8 @@ data Typ (pol     :: Polarity) where
   -- | Refinement types are represented by the presence of the TypeName parameter
   TyData          :: Loc -> PolarityRep pol               -> [XtorSig pol]           -> Typ pol
   TyCodata        :: Loc -> PolarityRep pol               -> [XtorSig (FlipPol pol)] -> Typ pol
-  TyDataRefined   :: Loc -> PolarityRep pol -> PolyKind -> RnTypeName -> Maybe RecTVar -> [XtorSig pol]           -> Typ pol
-  TyCodataRefined :: Loc -> PolarityRep pol -> PolyKind -> RnTypeName -> Maybe RecTVar -> [XtorSig (FlipPol pol)] -> Typ pol
+  TyDataRefined   :: Loc -> PolarityRep pol -> PolyKind -> RnTypeName -> [XtorSig pol]           -> Typ pol
+  TyCodataRefined :: Loc -> PolarityRep pol -> PolyKind -> RnTypeName -> [XtorSig (FlipPol pol)] -> Typ pol
   -- | Nominal types with arguments to type parameters (contravariant, covariant)
   TyNominal       :: Loc -> PolarityRep pol -> PolyKind -> RnTypeName  -> Typ pol
   TyApp           :: Loc -> PolarityRep pol -> Typ pol -> NonEmpty (VariantType pol) -> Typ pol
@@ -166,8 +166,8 @@ instance HasLoc (Typ pol) where
   getLoc (TyRecVar loc _ _)                = loc
   getLoc (TyData loc _ _)                  = loc
   getLoc (TyCodata loc _ _)                = loc
-  getLoc (TyDataRefined loc _ _ _ _ _)     = loc
-  getLoc (TyCodataRefined loc _ _ _ _ _)   = loc
+  getLoc (TyDataRefined loc _ _ _ _)     = loc
+  getLoc (TyCodataRefined loc _ _ _ _)   = loc
   getLoc (TyNominal loc _ _ _)             = loc
   getLoc (TyApp loc _ _ _)                 = loc
   getLoc (TySyn loc _ _ _)                 = loc
@@ -199,8 +199,8 @@ getPolarity (TyUniVar _ rep  _)             = rep
 getPolarity (TyRecVar _ rep  _)             = rep
 getPolarity (TyData _ rep _)                = rep
 getPolarity (TyCodata _ rep _)              = rep
-getPolarity (TyDataRefined _ rep _ _ _ _)   = rep
-getPolarity (TyCodataRefined _ rep _ _ _ _) = rep
+getPolarity (TyDataRefined _ rep _ _ _)   = rep
+getPolarity (TyCodataRefined _ rep _ _ _) = rep
 getPolarity (TyNominal _ rep  _ _)          = rep
 getPolarity (TyApp _ rep _ _)               = rep
 getPolarity (TySyn _ rep _ _)               = rep
@@ -237,8 +237,8 @@ instance ReplaceNominal (Typ pol) where
   replaceNominal _ _ _ ty@TyRecVar{}                     = ty
   replaceNominal p n t (TyData loc rep args)             = TyData loc rep (replaceNominal p n t <$> args)
   replaceNominal p n t (TyCodata loc rep args)           = TyCodata loc rep (replaceNominal p n t <$> args)
-  replaceNominal p n t (TyDataRefined loc rep pknd tn rv args)   = TyDataRefined loc rep pknd tn rv (replaceNominal p n t <$> args)
-  replaceNominal p n t (TyCodataRefined loc rep pknd tn rv args) = TyCodataRefined loc rep pknd tn rv (replaceNominal p n t <$> args)
+  replaceNominal p n t (TyDataRefined loc rep pknd tn args)   = TyDataRefined loc rep pknd tn (replaceNominal p n t <$> args)
+  replaceNominal p n t (TyCodataRefined loc rep pknd tn args) = TyCodataRefined loc rep pknd tn (replaceNominal p n t <$> args)
   replaceNominal p n t (TyNominal loc rep pk t')         = if t == t'
                                                            then case rep of { PosRep -> p; NegRep -> n }
                                                            else TyNominal loc rep pk t' 
@@ -313,8 +313,8 @@ instance FreeTVars (Typ pol) where
   freeTVars (TySyn _ _ _ ty)                  = freeTVars ty
   freeTVars (TyData _ _ xtors)                = S.unions (freeTVars <$> xtors)
   freeTVars (TyCodata _ _ xtors)              = S.unions (freeTVars <$> xtors)
-  freeTVars (TyDataRefined _ _ _ _ _ xtors)   = S.unions (freeTVars <$> xtors)
-  freeTVars (TyCodataRefined _ _ _ _ _ xtors) = S.unions (freeTVars <$> xtors)
+  freeTVars (TyDataRefined _ _ _ _ xtors)   = S.unions (freeTVars <$> xtors)
+  freeTVars (TyCodataRefined _ _ _ _ xtors) = S.unions (freeTVars <$> xtors)
   freeTVars (TyI64 _ _)                       = S.empty
   freeTVars (TyF64 _ _)                       = S.empty
   freeTVars (TyChar _ _)                      = S.empty

--- a/src/Dualize/Dualize.hs
+++ b/src/Dualize/Dualize.hs
@@ -230,14 +230,14 @@ dualType PosRep (TST.TyCodata loc _ eo xtors) =
   TST.TyData loc NegRep  (dualEvaluationOrder eo) xtors
 dualType NegRep (TST.TyCodata loc _ eo xtors) =
   TST.TyData loc PosRep  (dualEvaluationOrder eo) xtors 
-dualType PosRep (TST.TyDataRefined loc _ pk rn rv xtors) =
-  TST.TyCodataRefined loc NegRep  (dualPolyKind pk) (dualRnTypeName rn) rv xtors
-dualType NegRep (TST.TyDataRefined loc _ pk rn rv xtors) =
-  TST.TyCodataRefined loc PosRep  (dualPolyKind pk) (dualRnTypeName rn) rv xtors
-dualType PosRep (TST.TyCodataRefined loc _ pk rn rv xtors) =
-  TST.TyDataRefined loc NegRep  (dualPolyKind pk) (dualRnTypeName rn) rv xtors
-dualType NegRep (TST.TyCodataRefined loc _ pk rn rv xtors) =
-  TST.TyDataRefined loc PosRep  (dualPolyKind pk) (dualRnTypeName rn) rv xtors
+dualType PosRep (TST.TyDataRefined loc _ pk rn xtors) =
+  TST.TyCodataRefined loc NegRep  (dualPolyKind pk) (dualRnTypeName rn) xtors
+dualType NegRep (TST.TyDataRefined loc _ pk rn xtors) =
+  TST.TyCodataRefined loc PosRep  (dualPolyKind pk) (dualRnTypeName rn) xtors
+dualType PosRep (TST.TyCodataRefined loc _ pk rn xtors) =
+  TST.TyDataRefined loc NegRep  (dualPolyKind pk) (dualRnTypeName rn) xtors
+dualType NegRep (TST.TyCodataRefined loc _ pk rn xtors) =
+  TST.TyDataRefined loc PosRep  (dualPolyKind pk) (dualRnTypeName rn) xtors
 dualType _ (TST.TyFlipPol _ ty) = ty
 
 dualVariantType :: PolarityRep pol -> TST.VariantType pol -> TST.VariantType (FlipPol pol)

--- a/src/Pretty/TypeAutomata.hs
+++ b/src/Pretty/TypeAutomata.hs
@@ -36,8 +36,8 @@ instance PrettyAnn NodeLabel where
     intercalateX ";" (catMaybes [printDat <$> maybeDat
                                 , printCodat <$> maybeCodat
                                 , printNominal tns
-                                , printRefDat (fst refDat), printRV (snd refDat)
-                                , printRefCodat (fst refCodat), printRV (snd refCodat)
+                                , printRefDat refDat
+                                , printRefCodat refCodat 
                                 , Just $ prettyAnn knd])
     where
       printDat   dat   = mempty <+> cat (punctuate " , " (prettyAnn <$> S.toList dat)) <+> mempty
@@ -53,8 +53,6 @@ instance PrettyAnn NodeLabel where
         [] -> Nothing
         refTns -> Just $ intercalateX "; " $ (\(key, content) -> braces $ mempty <+>
           prettyAnn key <+> pipeSym <+> printCodat content <+> mempty) <$> refTns
-      printRV Nothing = Nothing
-      printRV (Just rv) = Just $ prettyAnn rv
 
 instance PrettyAnn (EdgeLabel a) where
   prettyAnn (EdgeSymbol _ xt Prd i) = prettyAnn xt <> parens (pretty i)

--- a/src/Pretty/Types.hs
+++ b/src/Pretty/Types.hs
@@ -130,6 +130,12 @@ instance PrettyAnn (TST.Typ pol) where
   prettyAnn typ = prettyAnn (embedTST typ)
 
 instance PrettyAnn CST.Typ where
+  -- special case for <TypeName | RecVar | Xtors> Syntax
+  prettyAnn (CST.TyRec _ rv (CST.TyXRefined _ CST.Data   tn xtors)) =
+    angles' mempty [prettyAnn tn <+> pipeSym, prettyAnn rv <+> pipeSym, hsep (intersperse commaSym (prettyAnn <$> xtors))] 
+  prettyAnn (CST.TyRec _ rv (CST.TyXRefined _ CST.Codata tn xtors)) =
+    braces' mempty [prettyAnn tn <+> pipeSym, prettyAnn rv <+> pipeSym, hsep (intersperse commaSym (prettyAnn <$> xtors))]
+
   -- Top and Bottom lattice types
   prettyAnn CST.TyTop {} = topSymUnicode
   prettyAnn CST.TyBot {} = botSymUnicode
@@ -158,15 +164,10 @@ instance PrettyAnn CST.Typ where
   prettyAnn (CST.TyXData _ CST.Codata xtors) =
     braces' commaSym (prettyAnn <$> xtors)
   -- Refinement types
-  prettyAnn (CST.TyXRefined _ CST.Data   tn Nothing xtors) =
+  prettyAnn (CST.TyXRefined _ CST.Data   tn xtors) =
     angles' mempty [prettyAnn tn <+> pipeSym, hsep (intersperse commaSym (prettyAnn <$> xtors))]
-  prettyAnn (CST.TyXRefined _ CST.Data   tn (Just rv) xtors) =
-    angles' mempty [prettyAnn tn <+> pipeSym, prettyAnn rv <+> pipeSym, hsep (intersperse commaSym (prettyAnn <$> xtors))] 
-  prettyAnn (CST.TyXRefined _ CST.Codata tn Nothing xtors) =
+  prettyAnn (CST.TyXRefined _ CST.Codata tn xtors) =
     braces' mempty [prettyAnn tn <+> pipeSym, hsep (intersperse commaSym (prettyAnn <$> xtors))]
-  prettyAnn (CST.TyXRefined _ CST.Codata tn (Just rv) xtors) =
-    braces' mempty [prettyAnn tn <+> pipeSym, prettyAnn rv <+> pipeSym, hsep (intersperse commaSym (prettyAnn <$> xtors))]
-
   -- Primitive types
   prettyAnn (CST.TyI64 _) = "#I64"
   prettyAnn (CST.TyF64 _) = "#F64"

--- a/src/Syntax/TST/Types.hs
+++ b/src/Syntax/TST/Types.hs
@@ -90,8 +90,8 @@ data Typ (pol :: Polarity) where
   -- | Refinement types are represented by the presence of the TypeName parameter
   TyData          :: Loc -> PolarityRep pol -> EvaluationOrder           -> [XtorSig pol]           -> Typ pol
   TyCodata        :: Loc -> PolarityRep pol -> EvaluationOrder           -> [XtorSig (FlipPol pol)] -> Typ pol
-  TyDataRefined   :: Loc -> PolarityRep pol -> PolyKind   -> RnTypeName  -> Maybe RecTVar -> [XtorSig pol]           -> Typ pol
-  TyCodataRefined :: Loc -> PolarityRep pol -> PolyKind   -> RnTypeName  -> Maybe RecTVar -> [XtorSig (FlipPol pol)] -> Typ pol
+  TyDataRefined   :: Loc -> PolarityRep pol -> PolyKind   -> RnTypeName  -> [XtorSig pol]           -> Typ pol
+  TyCodataRefined :: Loc -> PolarityRep pol -> PolyKind   -> RnTypeName  -> [XtorSig (FlipPol pol)] -> Typ pol
   -- | Nominal types with arguments to type parameters (contravariant, covariant)
   TyNominal       :: Loc -> PolarityRep pol -> PolyKind -> RnTypeName -> Typ pol
   TyApp           :: Loc -> PolarityRep pol -> Typ pol -> NonEmpty (VariantType pol) -> Typ pol
@@ -123,8 +123,8 @@ instance HasLoc (Typ pol) where
   getLoc (TyRecVar loc _ _ _)            = loc
   getLoc (TyData loc _ _ _ )             = loc
   getLoc (TyCodata loc _ _ _)            = loc
-  getLoc (TyDataRefined loc _ _ _ _ _)   = loc
-  getLoc (TyCodataRefined loc _ _ _ _ _) = loc
+  getLoc (TyDataRefined loc _ _ _ _)   = loc
+  getLoc (TyCodataRefined loc _ _ _ _) = loc
   getLoc (TyNominal loc _ _ _)           = loc
   getLoc (TyApp loc _ _ _)               = loc
   getLoc (TySyn loc _ _ _)               = loc
@@ -156,8 +156,8 @@ getPolarity (TyUniVar _ rep _ _)             = rep
 getPolarity (TyRecVar _ rep _ _)             = rep
 getPolarity (TyData _ rep _  _)              = rep
 getPolarity (TyCodata _ rep _  _)            = rep
-getPolarity (TyDataRefined _ rep  _ _ _ _)   = rep
-getPolarity (TyCodataRefined _ rep  _ _ _ _) = rep
+getPolarity (TyDataRefined _ rep  _ _ _)   = rep
+getPolarity (TyCodataRefined _ rep  _ _ _) = rep
 getPolarity (TyNominal _ rep _ _)            = rep
 getPolarity (TyApp _ rep _ _)                = rep
 getPolarity (TySyn _ rep _ _)                = rep
@@ -184,8 +184,8 @@ instance GetKind (Typ pol) where
   getKind (TyRecVar _ _ pk _)             = MkPknd pk 
   getKind (TyData _ _ eo _ )              = MkPknd $ MkPolyKind [] eo
   getKind (TyCodata _ _ eo _ )            = MkPknd $ MkPolyKind [] eo
-  getKind (TyDataRefined _ _ pk _ _ _)    = MkPknd pk
-  getKind (TyCodataRefined _ _ pk _ _ _)  = MkPknd pk
+  getKind (TyDataRefined _ _ pk _ _)    = MkPknd pk
+  getKind (TyCodataRefined _ _ pk _ _)  = MkPknd pk
   getKind (TyNominal _ _ pk _ )           = MkPknd pk
   getKind (TyApp _ _ ty _)                = getKind ty
   getKind (TySyn _ _ _ ty)                = getKind ty
@@ -251,8 +251,8 @@ instance FreeTVars (Typ pol) where
   freeTVars (TySyn _ _ _ ty)                   = freeTVars ty
   freeTVars (TyData _  _ _ xtors)              = S.unions (freeTVars <$> xtors)
   freeTVars (TyCodata _ _ _ xtors)             = S.unions (freeTVars <$> xtors)
-  freeTVars (TyDataRefined _ _ _ _ _ xtors)    = S.unions (freeTVars <$> xtors)
-  freeTVars (TyCodataRefined  _ _ _ _ _ xtors) = S.unions (freeTVars <$> xtors)
+  freeTVars (TyDataRefined _ _ _ _ xtors)    = S.unions (freeTVars <$> xtors)
+  freeTVars (TyCodataRefined  _ _ _ _ xtors) = S.unions (freeTVars <$> xtors)
   freeTVars (TyI64 _ _)                        = S.empty
   freeTVars (TyF64 _ _)                        = S.empty
   freeTVars (TyChar _ _)                       = S.empty
@@ -338,16 +338,16 @@ instance Zonk (Typ pol) where
      TyCodata loc rep knd (zonk UniRep bisubst <$> xtors)
   zonk vt bisubst (TyCodata loc rep mk xtors) =
      TyCodata loc rep mk (zonk vt bisubst <$> xtors)
-  zonk UniRep bisubst (TyDataRefined loc rep pk tn rv xtors) =
+  zonk UniRep bisubst (TyDataRefined loc rep pk tn xtors) =
      let knd = zonkKind (snd bisubst.bisubst_map)  pk in
-     TyDataRefined loc rep knd tn rv (zonk UniRep bisubst <$> xtors)
-  zonk vt bisubst (TyDataRefined loc rep pk tn rv xtors) =
-     TyDataRefined loc rep pk tn rv (zonk vt bisubst <$> xtors)
-  zonk UniRep bisubst (TyCodataRefined loc rep pk tn rv xtors) =
+     TyDataRefined loc rep knd tn (zonk UniRep bisubst <$> xtors)
+  zonk vt bisubst (TyDataRefined loc rep pk tn xtors) =
+     TyDataRefined loc rep pk tn (zonk vt bisubst <$> xtors)
+  zonk UniRep bisubst (TyCodataRefined loc rep pk tn xtors) =
      let knd = zonkKind (snd bisubst.bisubst_map) pk in
-     TyCodataRefined loc rep knd tn rv (zonk UniRep bisubst <$> xtors)
-  zonk vt bisubst (TyCodataRefined loc rep pk tn rv xtors) =
-     TyCodataRefined loc rep pk tn rv (zonk vt bisubst <$> xtors)
+     TyCodataRefined loc rep knd tn (zonk UniRep bisubst <$> xtors)
+  zonk vt bisubst (TyCodataRefined loc rep pk tn xtors) =
+     TyCodataRefined loc rep pk tn (zonk vt bisubst <$> xtors)
   zonk UniRep bisubst (TyNominal loc rep pk tn) = 
     let knd = zonkKind (snd $ bisubst.bisubst_map) pk in
     TyNominal loc rep knd tn 
@@ -438,10 +438,10 @@ instance ZonkKind (Typ pol) where
     TyData loc pol (zonkKind bisubst mk) (zonkKind bisubst <$> xtors)
   zonkKind bisubst (TyCodata loc pol mk xtors) = 
     TyCodata loc pol (zonkKind bisubst mk) (zonkKind bisubst <$> xtors)
-  zonkKind bisubst (TyDataRefined loc pol pk tyn rv xtors) = 
-    TyDataRefined loc pol (zonkKind bisubst pk) tyn rv (zonkKind bisubst <$> xtors)
-  zonkKind bisubst (TyCodataRefined loc pol pk tyn rv xtors) = 
-    TyCodataRefined loc pol (zonkKind bisubst pk) tyn rv (zonkKind bisubst <$> xtors)
+  zonkKind bisubst (TyDataRefined loc pol pk tyn xtors) = 
+    TyDataRefined loc pol (zonkKind bisubst pk) tyn (zonkKind bisubst <$> xtors)
+  zonkKind bisubst (TyCodataRefined loc pol pk tyn xtors) = 
+    TyCodataRefined loc pol (zonkKind bisubst pk) tyn (zonkKind bisubst <$> xtors)
   zonkKind bisubst (TyNominal loc pol pk tyn) = 
     TyNominal loc pol (zonkKind bisubst pk) tyn 
   zonkKind bisubst (TyApp loc pol ty args) = 

--- a/src/Translate/EmbedTST.hs
+++ b/src/Translate/EmbedTST.hs
@@ -140,14 +140,14 @@ instance EmbedTST (TST.Typ pol) (RST.Typ pol) where
     RST.TyKindAnnot (CBox eo) $ RST.TyData loc pol (map embedTST xtors)
   embedTST (TST.TyCodata loc pol eo xtors) =
     RST.TyKindAnnot (CBox eo) $ RST.TyCodata loc pol (map embedTST xtors)
-  embedTST (TST.TyDataRefined loc pol pk@(MkPolyKind _ rk) tn rv xtors) =
-    RST.TyKindAnnot (CBox rk) $ RST.TyDataRefined loc pol pk tn rv (map embedTST xtors)
-  embedTST (TST.TyDataRefined loc pol pk@(KindVar _) tn rv xtors) =
-    RST.TyDataRefined loc pol pk tn rv (map embedTST xtors)
-  embedTST (TST.TyCodataRefined loc pol pk@(MkPolyKind _ rk) tn rv xtors) = 
-    RST.TyKindAnnot (CBox rk) $ RST.TyCodataRefined loc pol pk tn rv (map embedTST xtors)
-  embedTST (TST.TyCodataRefined loc pol pk@(KindVar _) tn rv xtors) = 
-    RST.TyCodataRefined loc pol pk tn rv (map embedTST xtors)
+  embedTST (TST.TyDataRefined loc pol pk@(MkPolyKind _ rk) tn _ xtors) =
+    RST.TyKindAnnot (CBox rk) $ RST.TyDataRefined loc pol pk tn (map embedTST xtors)
+  embedTST (TST.TyDataRefined loc pol pk@(KindVar _) tn _ xtors) =
+    RST.TyDataRefined loc pol pk tn (map embedTST xtors)
+  embedTST (TST.TyCodataRefined loc pol pk@(MkPolyKind _ rk) tn _ xtors) = 
+    RST.TyKindAnnot (CBox rk) $ RST.TyCodataRefined loc pol pk tn (map embedTST xtors)
+  embedTST (TST.TyCodataRefined loc pol pk@(KindVar _) tn _ xtors) = 
+    RST.TyCodataRefined loc pol pk tn (map embedTST xtors)
   -- if arguments are applied to TyNominal, don't annotate the Kind, otherwise the parser will break after prettyprint
   embedTST (TST.TyApp loc pol (TST.TyNominal loc' pol' polyknd tn) args) = 
     RST.TyApp loc pol (RST.TyNominal loc' pol' polyknd tn) (embedTST <$> args)

--- a/src/Translate/EmbedTST.hs
+++ b/src/Translate/EmbedTST.hs
@@ -140,13 +140,13 @@ instance EmbedTST (TST.Typ pol) (RST.Typ pol) where
     RST.TyKindAnnot (CBox eo) $ RST.TyData loc pol (map embedTST xtors)
   embedTST (TST.TyCodata loc pol eo xtors) =
     RST.TyKindAnnot (CBox eo) $ RST.TyCodata loc pol (map embedTST xtors)
-  embedTST (TST.TyDataRefined loc pol pk@(MkPolyKind _ rk) tn _ xtors) =
+  embedTST (TST.TyDataRefined loc pol pk@(MkPolyKind _ rk) tn xtors) =
     RST.TyKindAnnot (CBox rk) $ RST.TyDataRefined loc pol pk tn (map embedTST xtors)
-  embedTST (TST.TyDataRefined loc pol pk@(KindVar _) tn _ xtors) =
+  embedTST (TST.TyDataRefined loc pol pk@(KindVar _) tn xtors) =
     RST.TyDataRefined loc pol pk tn (map embedTST xtors)
-  embedTST (TST.TyCodataRefined loc pol pk@(MkPolyKind _ rk) tn _ xtors) = 
+  embedTST (TST.TyCodataRefined loc pol pk@(MkPolyKind _ rk) tn xtors) = 
     RST.TyKindAnnot (CBox rk) $ RST.TyCodataRefined loc pol pk tn (map embedTST xtors)
-  embedTST (TST.TyCodataRefined loc pol pk@(KindVar _) tn _ xtors) = 
+  embedTST (TST.TyCodataRefined loc pol pk@(KindVar _) tn xtors) = 
     RST.TyCodataRefined loc pol pk tn (map embedTST xtors)
   -- if arguments are applied to TyNominal, don't annotate the Kind, otherwise the parser will break after prettyprint
   embedTST (TST.TyApp loc pol (TST.TyNominal loc' pol' polyknd tn) args) = 

--- a/src/TypeAutomata/Definition.hs
+++ b/src/TypeAutomata/Definition.hs
@@ -11,7 +11,7 @@ import Data.Functor.Identity
 import Data.Containers.ListUtils (nubOrd)
 import Data.Void
 
-import Syntax.CST.Names ( RnTypeName, XtorName, RecTVar )
+import Syntax.CST.Names ( RnTypeName, XtorName )
 import Syntax.CST.Types ( DataCodata(..), Arity, PrdCns(..))
 import Syntax.RST.Types ( Polarity, PolarityRep(..))
 import Syntax.CST.Kinds ( Variance, PolyKind(..),AnyKind(..))
@@ -164,8 +164,8 @@ data NodeLabel =
     , nl_codata :: Maybe (Set XtorLabel)
     -- Nominal type names with the arities of type parameters
     , nl_nominal :: Set (RnTypeName, [Variance])
-    , nl_ref_data :: (Map RnTypeName (Set XtorLabel), Maybe RecTVar)
-    , nl_ref_codata :: (Map RnTypeName (Set XtorLabel), Maybe RecTVar)
+    , nl_ref_data :: Map RnTypeName (Set XtorLabel)
+    , nl_ref_codata :: Map RnTypeName (Set XtorLabel)
     , nl_kind :: PolyKind 
     }
   |
@@ -176,20 +176,20 @@ data NodeLabel =
 
 emptyNodeLabel :: Polarity -> AnyKind -> NodeLabel
 emptyNodeLabel _ (MkPknd (KindVar _)) = error "at this point no KindVars should be in the program"
-emptyNodeLabel pol (MkPknd pk)  = MkNodeLabel pol Nothing Nothing S.empty (M.empty, Nothing) (M.empty,Nothing) pk
+emptyNodeLabel pol (MkPknd pk)  = MkNodeLabel pol Nothing Nothing S.empty M.empty M.empty pk
 emptyNodeLabel pol MkI64        = MkPrimitiveNodeLabel pol I64
 emptyNodeLabel pol MkF64        = MkPrimitiveNodeLabel pol F64
 emptyNodeLabel pol MkString     = MkPrimitiveNodeLabel pol PString
 emptyNodeLabel pol MkChar       = MkPrimitiveNodeLabel pol PChar
 
 singleNodeLabelNominal :: Polarity -> (RnTypeName, [Variance]) ->  PolyKind -> NodeLabel
-singleNodeLabelNominal pol nominal k = MkNodeLabel { nl_pol = pol, nl_data = Nothing, nl_codata = Nothing, nl_nominal = S.singleton nominal, nl_ref_data = (M.empty, Nothing), nl_ref_codata = (M.empty, Nothing), nl_kind = k }
+singleNodeLabelNominal pol nominal k = MkNodeLabel { nl_pol = pol, nl_data = Nothing, nl_codata = Nothing, nl_nominal = S.singleton nominal, nl_ref_data = M.empty, nl_ref_codata = M.empty, nl_kind = k }
 
-singleNodeLabelXtor :: Polarity -> DataCodata -> Maybe (RnTypeName, Maybe RecTVar) -> Set XtorLabel -> PolyKind -> NodeLabel
-singleNodeLabelXtor pol Data   Nothing   xtors k      = MkNodeLabel { nl_pol = pol, nl_data = Just xtors, nl_codata = Nothing,    nl_nominal = S.empty, nl_ref_data = (M.empty, Nothing),         nl_ref_codata = (M.empty, Nothing),         nl_kind = k }
-singleNodeLabelXtor pol Codata Nothing   xtors k      = MkNodeLabel { nl_pol = pol, nl_data = Nothing,    nl_codata = Just xtors, nl_nominal = S.empty, nl_ref_data = (M.empty, Nothing),         nl_ref_codata = (M.empty, Nothing),         nl_kind = k }
-singleNodeLabelXtor pol Data   (Just (tn,rv)) xtors k = MkNodeLabel { nl_pol = pol, nl_data = Nothing,    nl_codata = Nothing,    nl_nominal = S.empty, nl_ref_data = (M.singleton tn xtors, rv), nl_ref_codata = (M.empty, Nothing),         nl_kind = k }
-singleNodeLabelXtor pol Codata (Just (tn,rv)) xtors k = MkNodeLabel { nl_pol = pol, nl_data = Nothing,    nl_codata = Nothing,    nl_nominal = S.empty, nl_ref_data = (M.empty, Nothing),         nl_ref_codata = (M.singleton tn xtors, rv), nl_kind = k }
+singleNodeLabelXtor :: Polarity -> DataCodata -> Maybe RnTypeName -> Set XtorLabel -> PolyKind -> NodeLabel
+singleNodeLabelXtor pol Data   Nothing   xtors k = MkNodeLabel { nl_pol = pol, nl_data = Just xtors, nl_codata = Nothing,    nl_nominal = S.empty, nl_ref_data = M.empty,              nl_ref_codata = M.empty,         nl_kind = k }
+singleNodeLabelXtor pol Codata Nothing   xtors k = MkNodeLabel { nl_pol = pol, nl_data = Nothing,    nl_codata = Just xtors, nl_nominal = S.empty, nl_ref_data = M.empty,              nl_ref_codata = M.empty,         nl_kind = k }
+singleNodeLabelXtor pol Data   (Just tn) xtors k = MkNodeLabel { nl_pol = pol, nl_data = Nothing,    nl_codata = Nothing,    nl_nominal = S.empty, nl_ref_data = M.singleton tn xtors, nl_ref_codata = M.empty,         nl_kind = k }
+singleNodeLabelXtor pol Codata (Just tn) xtors k = MkNodeLabel { nl_pol = pol, nl_data = Nothing,    nl_codata = Nothing,    nl_nominal = S.empty, nl_ref_data = M.empty,              nl_ref_codata = M.singleton tn xtors, nl_kind = k }
 
 getPolarityNL :: NodeLabel -> Polarity
 getPolarityNL (MkNodeLabel pol _ _ _ _ _ _) = pol

--- a/src/TypeAutomata/Determinize.hs
+++ b/src/TypeAutomata/Determinize.hs
@@ -88,10 +88,8 @@ combineNodeLabels (fstLabel@MkNodeLabel{}:rs) =
             nl_data = mrgDat [xtors | MkNodeLabel _ (Just xtors) _ _ _ _ _ <- [fstLabel,combLabel]],
             nl_codata = mrgCodat [xtors | MkNodeLabel _ _ (Just xtors) _ _ _ _ <- [fstLabel,combLabel]],
             nl_nominal = S.unions [tn | MkNodeLabel _ _ _ tn _ _ _ <- [fstLabel, combLabel]],
-            nl_ref_data = (mrgRefDat [refs | MkNodeLabel _ _ _ _ refs _ _ <- [fstLabel, combLabel]], 
-                           mrgRecVars (snd fstLabel.nl_ref_data, snd combLabel.nl_ref_data)),
-            nl_ref_codata = (mrgRefCodat [refs | MkNodeLabel _ _ _ _ _ refs _ <- [fstLabel, combLabel]],
-                            mrgRecVars (snd fstLabel.nl_ref_codata, snd combLabel.nl_ref_codata)),
+            nl_ref_data = mrgRefDat [refs | MkNodeLabel _ _ _ _ refs _ _ <- [fstLabel, combLabel]], 
+            nl_ref_codata = mrgRefCodat [refs | MkNodeLabel _ _ _ _ _ refs _ <- [fstLabel, combLabel]], 
             nl_kind = MkPolyKind (mrgKindArgs combLabel.nl_kind.kindArgs knd.kindArgs) knd.returnKind
           }
         else
@@ -106,15 +104,12 @@ combineNodeLabels (fstLabel@MkNodeLabel{}:rs) =
     mrgCodat [] = Nothing
     mrgCodat (xtor:xtors) = Just $ case pol of {Pos -> intersections (xtor :| xtors); Neg -> S.unions (xtor:xtors)}
     mrgRefDat refs = case pol of
-      Pos -> M.unionsWith S.union (map fst refs)
-      Neg -> M.unionsWith S.intersection (map fst refs)
+      Pos -> M.unionsWith S.union refs
+      Neg -> M.unionsWith S.intersection refs
     mrgRefCodat refs = case pol of
-      Pos -> M.unionsWith S.intersection (map fst refs)
-      Neg -> M.unionsWith S.union (map fst refs)
+      Pos -> M.unionsWith S.intersection refs
+      Neg -> M.unionsWith S.union refs
     rs_merged = combineNodeLabels rs
-    mrgRecVars (Nothing,Nothing) = Nothing
-    mrgRecVars (Just r1,_) = Just r1
-    mrgRecVars (_,Just r2) = Just r2
     mrgKindArgs [] knds = knds
     mrgKindArgs knds [] = knds
     mrgKindArgs (knd1:knds1) knds2 = if knd1 `elem` knds2 then mrgKindArgs knds1 knds2 else knd1:mrgKindArgs knds1 knds2

--- a/src/TypeAutomata/FromAutomaton.hs
+++ b/src/TypeAutomata/FromAutomaton.hs
@@ -175,8 +175,8 @@ nodeToTypeNoCache rep i  = do
     MkNodeLabel _ datSet codatSet tns refDat refCodat pk@(MkPolyKind _ _) -> do
       outs <- nodeToOuts i
       let (maybeDat,maybeCodat) = (S.toList <$> datSet, S.toList <$> codatSet)
-      let refDatTypes = M.toList (fst refDat) -- Unique data ref types
-      let refCodatTypes = M.toList (fst refCodat) -- Unique codata ref types
+      let refDatTypes = M.toList refDat -- Unique data ref types
+      let refCodatTypes = M.toList refCodat -- Unique codata ref types
       resType <- local (visitNode i) $ do
         -- Creating type variables
         varL <- nodeToTVars rep i
@@ -205,7 +205,7 @@ nodeToTypeNoCache rep i  = do
               let nodes = computeArgNodes outs CST.Data xt
               argTypes <- argNodesToArgTypes nodes rep
               return (MkXtorSig xt.labelName argTypes)
-            return $ TyDataRefined defaultLoc rep pk tn (snd refDat) sig
+            return $ TyDataRefined defaultLoc rep pk tn sig
         -- Creating ref codata types
         refCodatL <- do
           forM refCodatTypes $ \(tn,xtors) -> do
@@ -213,7 +213,7 @@ nodeToTypeNoCache rep i  = do
               let nodes = computeArgNodes outs CST.Codata xt
               argTypes <- argNodesToArgTypes nodes (flipPolarityRep rep)
               return (MkXtorSig xt.labelName argTypes)
-            return $ TyCodataRefined defaultLoc rep pk tn (snd refCodat) sig
+            return $ TyCodataRefined defaultLoc rep pk tn sig
         -- Creating Nominal types
         let adjEdges = lsuc gr i
         let typeArgsMap :: Map (RnTypeName, Int) (Node, Variance) = M.fromList [((tn, i), (node,var)) | (node, TypeArgEdge tn var i) <- adjEdges]

--- a/src/TypeAutomata/Intersection.hs
+++ b/src/TypeAutomata/Intersection.hs
@@ -81,15 +81,9 @@ intersectLabels (MkNodeLabel pol  data'  codata  nominal  ref_data  ref_codata  
  | otherwise = Just $ MkNodeLabel pol (S.intersection <$> data' <*> data'')
                                       (S.intersection <$> codata <*> codata')
                                       (S.intersection nominal nominal')
-                                      (M.intersectionWith S.intersection (fst ref_data) (fst ref_data'),
-                                        mrgRecVars (snd ref_data,snd ref_data'))
-                                      (M.intersectionWith S.intersection (fst ref_codata) (fst ref_codata'),
-                                        mrgRecVars (snd ref_data,snd ref_data'))
-                                        kind
-  where 
-    mrgRecVars (Nothing, Nothing) = Nothing
-    mrgRecVars (Just r1,_) = Just r1
-    mrgRecVars (_,Just r2) = Just r2
+                                      (M.intersectionWith S.intersection ref_data ref_data')
+                                      (M.intersectionWith S.intersection ref_codata ref_codata')
+                                      kind
 intersectLabels (MkPrimitiveNodeLabel pol prim)
                 (MkPrimitiveNodeLabel pol' prim')
  | pol /= pol' = Nothing

--- a/src/TypeAutomata/ToAutomaton.hs
+++ b/src/TypeAutomata/ToAutomaton.hs
@@ -177,7 +177,7 @@ lookupTRecVar NegRep tv = do
 sigToLabel :: XtorSig pol -> XtorLabel
 sigToLabel (MkXtorSig name ctxt) = MkXtorLabel name (linearContextToArity ctxt)
 
-insertXtors :: CST.DataCodata -> Polarity -> Maybe (RnTypeName, Maybe RecTVar) -> PolyKind -> [XtorSig pol] -> TTA Node
+insertXtors :: CST.DataCodata -> Polarity -> Maybe RnTypeName -> PolyKind -> [XtorSig pol] -> TTA Node
 insertXtors dc pol mtn pk xtors = do
   newNode <- newNodeM
   insertNode newNode (singleNodeLabelXtor pol dc mtn (S.fromList (sigToLabel <$> xtors)) pk)
@@ -239,8 +239,8 @@ insertType (TyRec _ rep rv ty) = do
   return newNode
 insertType (TyData _  polrep eo xtors)   = insertXtors CST.Data   (polarityRepToPol polrep) Nothing (MkPolyKind [] eo) xtors
 insertType (TyCodata _ polrep eo  xtors) = insertXtors CST.Codata (polarityRepToPol polrep) Nothing (MkPolyKind [] eo) xtors
-insertType (TyDataRefined _ polrep pk mtn rv xtors)   = insertXtors CST.Data   (polarityRepToPol polrep) (Just (mtn,rv)) pk xtors
-insertType (TyCodataRefined _ polrep pk mtn rv xtors) = insertXtors CST.Codata (polarityRepToPol polrep) (Just (mtn,rv)) pk xtors
+insertType (TyDataRefined _ polrep pk mtn xtors)   = insertXtors CST.Data   (polarityRepToPol polrep) (Just mtn) pk xtors
+insertType (TyCodataRefined _ polrep pk mtn xtors) = insertXtors CST.Codata (polarityRepToPol polrep) (Just mtn) pk xtors
 insertType (TySyn _ _ _ ty) = insertType ty
 insertType (TyApp _ _ (TyNominal _ rep polyknd tn) args) = do
   let pol = polarityRepToPol rep

--- a/src/TypeAutomata/Utils.hs
+++ b/src/TypeAutomata/Utils.hs
@@ -8,7 +8,7 @@ module TypeAutomata.Utils
 import Data.Map (Map)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
-import Data.Maybe (fromJust,isNothing)
+import Data.Maybe (fromJust)
 import Data.Tuple (swap)
 import Data.Graph.Inductive.Graph (Node, lab, lsuc, DynGraph, Graph (..))
 
@@ -46,7 +46,7 @@ sucWith gr i el = lookup el (map swap (lsuc gr i))
 
 isEmptyLabel :: NodeLabel -> Bool
 isEmptyLabel nl@MkNodeLabel{}
-             = nothingOrEmpty nl.nl_data && nothingOrEmpty nl.nl_codata && S.null nl.nl_nominal && mapNull (fst nl.nl_ref_data) && mapNull (fst nl.nl_ref_codata) && isNothing (snd nl.nl_ref_data) && isNothing (snd nl.nl_ref_codata)
+             = nothingOrEmpty nl.nl_data && nothingOrEmpty nl.nl_codata && S.null nl.nl_nominal && mapNull nl.nl_ref_data && mapNull nl.nl_ref_codata 
   where nothingOrEmpty Nothing = True
         nothingOrEmpty (Just s) = S.null s
         mapNull = M.foldr (\x y -> S.null x && y) True

--- a/src/TypeInference/Coalescing.hs
+++ b/src/TypeInference/Coalescing.hs
@@ -144,12 +144,12 @@ coalesceType (TyData loc rep mk xtors) = do
 coalesceType (TyCodata loc rep mk xtors) = do
     xtors' <- mapM coalesceXtor xtors
     return (TyCodata loc rep mk xtors')
-coalesceType (TyDataRefined loc rep mk tn rv xtors) = do
+coalesceType (TyDataRefined loc rep mk tn xtors) = do
     xtors' <- mapM coalesceXtor xtors
-    return (TyDataRefined loc rep mk tn rv xtors')
-coalesceType (TyCodataRefined loc rep mk tn rv xtors) = do
+    return (TyDataRefined loc rep mk tn xtors')
+coalesceType (TyCodataRefined loc rep mk tn xtors) = do
     xtors' <- mapM coalesceXtor xtors
-    return (TyCodataRefined loc rep mk tn rv xtors')
+    return (TyCodataRefined loc rep mk tn xtors')
 coalesceType (TyNominal loc rep mk tn) = do
     return $ TyNominal loc rep mk tn 
 coalesceType (TyApp loc rep ty args) = do 

--- a/src/TypeInference/GenerateConstraints/Kinds.hs
+++ b/src/TypeInference/GenerateConstraints/Kinds.hs
@@ -187,21 +187,21 @@ annotTy (RST.TyDataRefined loc pol pknd tyn xtors) =  do
   if tyn == tyn' then do
     let xtorNames = map (\x -> x.sig_name) xtors
     xtors' <- getXtors pol xtorNames
-    return $ TST.TyDataRefined loc pol pknd tyn Nothing xtors' 
+    return $ TST.TyDataRefined loc pol pknd tyn xtors' 
   else do 
     decl <- lookupTypeName loc tyn
     let xtors' = (case pol of RST.PosRep -> fst; RST.NegRep -> snd) decl.data_xtors 
-    return $ TST.TyDataRefined loc pol pknd tyn Nothing xtors' 
+    return $ TST.TyDataRefined loc pol pknd tyn xtors' 
 annotTy (RST.TyCodataRefined loc pol pknd tyn xtors) = do 
   tyn' <- gets (\x -> x.declTyName)
   if tyn == tyn' then do 
     let xtorNames = map (\x -> x.sig_name) xtors
     xtors' <- getXtors (RST.flipPolarityRep pol) xtorNames
-    return $ TST.TyCodataRefined loc pol pknd tyn Nothing xtors'
+    return $ TST.TyCodataRefined loc pol pknd tyn xtors'
   else do
     decl <- lookupTypeName loc tyn
     let xtors' = (case pol of RST.PosRep -> snd; RST.NegRep -> fst) decl.data_xtors
-    return $ TST.TyCodataRefined loc pol pknd tyn Nothing xtors'
+    return $ TST.TyCodataRefined loc pol pknd tyn xtors'
 annotTy (RST.TyApp loc pol ty args) = do 
   ty' <- annotTy ty 
   args' <- mapM annotVarTy args
@@ -236,11 +236,11 @@ annotTy (RST.TyRec loc pol rv ty) = case ty of
   RST.TyDataRefined loc' pol' pknd tyn xtors -> do 
     addRecVar rv pknd
     xtors' <- mapM annotXtor xtors
-    return $ TST.TyRec loc pol rv (TST.TyDataRefined loc' pol' pknd tyn Nothing xtors')
+    return $ TST.TyRec loc pol rv (TST.TyDataRefined loc' pol' pknd tyn xtors')
   RST.TyCodataRefined loc' pol' pknd tyn xtors -> do
     addRecVar rv pknd
     xtors' <- mapM annotXtor xtors
-    return $ TST.TyRec loc pol rv (TST.TyCodataRefined loc' pol' pknd tyn Nothing xtors')
+    return $ TST.TyRec loc pol rv (TST.TyCodataRefined loc' pol' pknd tyn xtors')
   _ -> throwOtherError loc ["TyRec can only appear inside Refinement Declaration"]
 annotTy (RST.TyI64 loc pol) = return $ TST.TyI64 loc pol
 annotTy (RST.TyF64 loc pol) = return $ TST.TyF64 loc pol
@@ -501,7 +501,7 @@ instance AnnotateKind (RST.Typ pol) (TST.Typ pol) where
     xtors' <- mapM annotateKind xtors
     decl <- lookupTypeName loc tyn
     checkXtors loc xtors' decl
-    return (TST.TyDataRefined loc pol pknd tyn Nothing xtors')
+    return (TST.TyDataRefined loc pol pknd tyn xtors')
     where 
       checkXtors :: Loc -> [TST.XtorSig pol] -> TST.DataDecl -> GenM ()
       checkXtors _ [] _ = return ()
@@ -518,7 +518,7 @@ instance AnnotateKind (RST.Typ pol) (TST.Typ pol) where
     xtors' <- mapM annotateKind xtors
     decl <- lookupTypeName loc tyn
     checkXtors loc xtors' decl
-    return (TST.TyCodataRefined loc pol pknd tyn Nothing xtors')
+    return (TST.TyCodataRefined loc pol pknd tyn xtors')
     where 
       checkXtors :: Loc -> [TST.XtorSig (RST.FlipPol pol)] -> TST.DataDecl -> GenM ()
       checkXtors _ [] _ = return ()

--- a/src/TypeInference/GenerateConstraints/Kinds.hs
+++ b/src/TypeInference/GenerateConstraints/Kinds.hs
@@ -182,26 +182,26 @@ annotTy (RST.TyCodata loc pol xtors) = do
     compXtorKinds [] = Nothing 
     compXtorKinds [mk] = Just mk
     compXtorKinds (xtor1:xtor2:rst) = if xtor1==xtor2 then compXtorKinds (xtor2:rst) else Nothing
-annotTy (RST.TyDataRefined loc pol pknd tyn rv xtors) =  do 
+annotTy (RST.TyDataRefined loc pol pknd tyn xtors) =  do 
   tyn' <- gets (\x -> x.declTyName)
   if tyn == tyn' then do
     let xtorNames = map (\x -> x.sig_name) xtors
     xtors' <- getXtors pol xtorNames
-    return $ TST.TyDataRefined loc pol pknd tyn rv xtors' 
+    return $ TST.TyDataRefined loc pol pknd tyn Nothing xtors' 
   else do 
     decl <- lookupTypeName loc tyn
     let xtors' = (case pol of RST.PosRep -> fst; RST.NegRep -> snd) decl.data_xtors 
-    return $ TST.TyDataRefined loc pol pknd tyn rv xtors' 
-annotTy (RST.TyCodataRefined loc pol pknd tyn rv xtors) = do 
+    return $ TST.TyDataRefined loc pol pknd tyn Nothing xtors' 
+annotTy (RST.TyCodataRefined loc pol pknd tyn xtors) = do 
   tyn' <- gets (\x -> x.declTyName)
   if tyn == tyn' then do 
     let xtorNames = map (\x -> x.sig_name) xtors
     xtors' <- getXtors (RST.flipPolarityRep pol) xtorNames
-    return $ TST.TyCodataRefined loc pol pknd tyn rv xtors'
+    return $ TST.TyCodataRefined loc pol pknd tyn Nothing xtors'
   else do
     decl <- lookupTypeName loc tyn
     let xtors' = (case pol of RST.PosRep -> snd; RST.NegRep -> fst) decl.data_xtors
-    return $ TST.TyCodataRefined loc pol pknd tyn rv xtors'
+    return $ TST.TyCodataRefined loc pol pknd tyn Nothing xtors'
 annotTy (RST.TyApp loc pol ty args) = do 
   ty' <- annotTy ty 
   args' <- mapM annotVarTy args
@@ -233,14 +233,14 @@ annotTy (RST.TyInter loc ty1 ty2) = do
 annotTy (RST.TyRec loc pol rv ty) = case ty of 
   -- recursive types can only appear inside Refinement declarations
   -- when they do, the recvars always represent the type that is being refined
-  RST.TyDataRefined loc' pol' pknd tyn mrv xtors -> do 
+  RST.TyDataRefined loc' pol' pknd tyn xtors -> do 
     addRecVar rv pknd
     xtors' <- mapM annotXtor xtors
-    return $ TST.TyRec loc pol rv (TST.TyDataRefined loc' pol' pknd tyn mrv xtors')
-  RST.TyCodataRefined loc' pol' pknd tyn mrv xtors -> do
+    return $ TST.TyRec loc pol rv (TST.TyDataRefined loc' pol' pknd tyn Nothing xtors')
+  RST.TyCodataRefined loc' pol' pknd tyn xtors -> do
     addRecVar rv pknd
     xtors' <- mapM annotXtor xtors
-    return $ TST.TyRec loc pol rv (TST.TyCodataRefined loc' pol' pknd tyn mrv xtors')
+    return $ TST.TyRec loc pol rv (TST.TyCodataRefined loc' pol' pknd tyn Nothing xtors')
   _ -> throwOtherError loc ["TyRec can only appear inside Refinement Declaration"]
 annotTy (RST.TyI64 loc pol) = return $ TST.TyI64 loc pol
 annotTy (RST.TyF64 loc pol) = return $ TST.TyF64 loc pol
@@ -265,12 +265,11 @@ annotTy (RST.TyKindAnnot mk ty) = do
 computeEmptyRefinementType :: CST.DataCodata
                            -> RnTypeName
                            -> PolyKind
-                           -> Maybe RecTVar
                            -> DataDeclM (RST.Typ Pos, RST.Typ Neg)
-computeEmptyRefinementType CST.Data tn polyknd mrv = do 
-  pure (RST.TyDataRefined   defaultLoc PosRep polyknd tn mrv [], RST.TyDataRefined   defaultLoc NegRep polyknd tn mrv [])
-computeEmptyRefinementType CST.Codata tn polyknd mrv = do 
-  pure (RST.TyCodataRefined defaultLoc PosRep polyknd tn mrv [], RST.TyCodataRefined defaultLoc NegRep polyknd tn mrv [])
+computeEmptyRefinementType CST.Data tn polyknd = do 
+  pure (RST.TyDataRefined   defaultLoc PosRep polyknd tn [], RST.TyDataRefined   defaultLoc NegRep polyknd tn [])
+computeEmptyRefinementType CST.Codata tn polyknd = do 
+  pure (RST.TyCodataRefined defaultLoc PosRep polyknd tn [], RST.TyCodataRefined defaultLoc NegRep polyknd tn [])
 
 -- | Given the polarity (data/codata), the name and the constructors/destructors of a type, compute the
 -- full refinement of that type.
@@ -282,9 +281,8 @@ computeFullRefinementType :: CST.DataCodata
                           -> RnTypeName
                           -> ([RST.XtorSig Pos], [RST.XtorSig Neg])
                           -> PolyKind
-                          -> Maybe RecTVar
                           -> DataDeclM (RST.Typ Pos, RST.Typ Neg)
-computeFullRefinementType dc tn (xtorsPos, xtorsNeg) polyknd mrv = do
+computeFullRefinementType dc tn (xtorsPos, xtorsNeg) polyknd = do
   -- Define the variable that stands for the recursive occurrences in the translation.
   let recVar = MkRecTVar "α"
   let recVarPos = RST.TyRecVar defaultLoc PosRep recVar
@@ -294,11 +292,11 @@ computeFullRefinementType dc tn (xtorsPos, xtorsNeg) polyknd mrv = do
   let xtorsReplacedNeg :: [RST.XtorSig Neg] = RST.replaceNominal recVarPos recVarNeg tn <$> xtorsNeg
   -- Assemble the 
   let fullRefinementTypePos :: RST.Typ Pos = case dc of
-                   CST.Data   -> RST.TyRec defaultLoc PosRep recVar (RST.TyDataRefined   defaultLoc PosRep polyknd tn mrv xtorsReplacedPos)
-                   CST.Codata -> RST.TyRec defaultLoc PosRep recVar (RST.TyCodataRefined defaultLoc PosRep polyknd tn mrv xtorsReplacedNeg)
+                   CST.Data   -> RST.TyRec defaultLoc PosRep recVar (RST.TyDataRefined   defaultLoc PosRep polyknd tn xtorsReplacedPos)
+                   CST.Codata -> RST.TyRec defaultLoc PosRep recVar (RST.TyCodataRefined defaultLoc PosRep polyknd tn xtorsReplacedNeg)
   let fullRefinementTypeNeg :: RST.Typ Neg = case dc of
-                   CST.Data   -> RST.TyRec defaultLoc NegRep recVar (RST.TyDataRefined defaultLoc NegRep polyknd tn   mrv xtorsReplacedNeg)
-                   CST.Codata -> RST.TyRec defaultLoc NegRep recVar (RST.TyCodataRefined defaultLoc NegRep polyknd tn mrv xtorsReplacedPos)
+                   CST.Data   -> RST.TyRec defaultLoc NegRep recVar (RST.TyDataRefined defaultLoc NegRep polyknd tn    xtorsReplacedNeg)
+                   CST.Codata -> RST.TyRec defaultLoc NegRep recVar (RST.TyCodataRefined defaultLoc NegRep polyknd tn  xtorsReplacedPos)
   pure (fullRefinementTypePos, fullRefinementTypeNeg)
 
 annotateDataDecl :: RST.DataDecl -> DataDeclM TST.DataDecl 
@@ -329,10 +327,10 @@ annotateDataDecl RST.RefinementDecl {
   data_xtors = xtors
   } = do
     -- Compute the full and empty refinement types:
-    (emptyPos, emptyNeg) <- computeEmptyRefinementType pol tyn polyknd Nothing
+    (emptyPos, emptyNeg) <- computeEmptyRefinementType pol tyn polyknd
     emptPos' <- annotTy emptyPos
     emptNeg' <- annotTy emptyNeg
-    (fulPos, fulNeg) <- computeFullRefinementType pol tyn xtors polyknd Nothing
+    (fulPos, fulNeg) <- computeFullRefinementType pol tyn xtors polyknd
     fulPos' <- annotTy fulPos
     fulNeg' <- annotTy fulNeg
     -- Compute the annotated xtors (without refinement)
@@ -499,11 +497,11 @@ instance AnnotateKind (RST.Typ pol) (TST.Typ pol) where
         return ()
       checkRetKnd loc primk eo = throwOtherError loc ["Kinds " <> ppPrint primk <> " and " <> ppPrint eo <> " are not compatible"]
  
-  annotateKind (RST.TyDataRefined loc pol pknd tyn  rv xtors) = do 
+  annotateKind (RST.TyDataRefined loc pol pknd tyn xtors) = do 
     xtors' <- mapM annotateKind xtors
     decl <- lookupTypeName loc tyn
     checkXtors loc xtors' decl
-    return (TST.TyDataRefined loc pol pknd tyn rv xtors')
+    return (TST.TyDataRefined loc pol pknd tyn Nothing xtors')
     where 
       checkXtors :: Loc -> [TST.XtorSig pol] -> TST.DataDecl -> GenM ()
       checkXtors _ [] _ = return ()
@@ -516,11 +514,11 @@ instance AnnotateKind (RST.Typ pol) (TST.Typ pol) where
         else 
           throwOtherError loc ["Xtors do not have the correct kinds"]
 
-  annotateKind (RST.TyCodataRefined loc pol pknd tyn rv xtors) = do
+  annotateKind (RST.TyCodataRefined loc pol pknd tyn xtors) = do
     xtors' <- mapM annotateKind xtors
     decl <- lookupTypeName loc tyn
     checkXtors loc xtors' decl
-    return (TST.TyCodataRefined loc pol pknd tyn rv xtors')
+    return (TST.TyCodataRefined loc pol pknd tyn Nothing xtors')
     where 
       checkXtors :: Loc -> [TST.XtorSig (RST.FlipPol pol)] -> TST.DataDecl -> GenM ()
       checkXtors _ [] _ = return ()

--- a/src/TypeInference/GenerateConstraints/Terms.hs
+++ b/src/TypeInference/GenerateConstraints/Terms.hs
@@ -149,8 +149,8 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
     -- and the translations of the types we looked up, i.e. the types declared in the XtorSig.
     genConstraintsCtxts substTypes xtorSigUpper.sig_args (case rep of { PrdRep -> CtorArgsConstraint loc; CnsRep -> DtorArgsConstraint loc })
     case rep of
-      PrdRep -> return (TST.Xtor loc annot rep (TST.TyDataRefined   defaultLoc PosRep decl.data_kind decl.data_name Nothing [TST.MkXtorSig xt substTypes]) CST.Refinement xt substInferred)
-      CnsRep -> return (TST.Xtor loc annot rep (TST.TyCodataRefined defaultLoc NegRep decl.data_kind decl.data_name Nothing [TST.MkXtorSig xt substTypes]) CST.Refinement xt substInferred)
+      PrdRep -> return (TST.Xtor loc annot rep (TST.TyDataRefined   defaultLoc PosRep decl.data_kind decl.data_name [TST.MkXtorSig xt substTypes]) CST.Refinement xt substInferred)
+      CnsRep -> return (TST.Xtor loc annot rep (TST.TyCodataRefined defaultLoc NegRep decl.data_kind decl.data_name [TST.MkXtorSig xt substTypes]) CST.Refinement xt substInferred)
   --
   -- Structural pattern and copattern matches:
   --
@@ -244,8 +244,8 @@ instance GenConstraints (Core.Term pc) (TST.Term pc) where
                         -- and greatest type translation.
                         return (TST.MkCmdCase cmdcase_loc (Core.XtorPat loc xt args) cmdInferred, TST.MkXtorSig xt uvarsNeg))
     case rep of
-      PrdRep -> return $ TST.XCase loc annot rep (TST.TyCodataRefined defaultLoc PosRep decl.data_kind decl.data_name Nothing (snd <$> inferredCases)) CST.Refinement (fst <$> inferredCases)
-      CnsRep -> return $ TST.XCase loc annot rep (TST.TyDataRefined   defaultLoc NegRep decl.data_kind decl.data_name Nothing (snd <$> inferredCases)) CST.Refinement (fst <$> inferredCases)
+      PrdRep -> return $ TST.XCase loc annot rep (TST.TyCodataRefined defaultLoc PosRep decl.data_kind decl.data_name (snd <$> inferredCases)) CST.Refinement (fst <$> inferredCases)
+      CnsRep -> return $ TST.XCase loc annot rep (TST.TyDataRefined   defaultLoc NegRep decl.data_kind decl.data_name (snd <$> inferredCases)) CST.Refinement (fst <$> inferredCases)
   --
   -- Mu and TildeMu abstractions:
   --

--- a/src/TypeInference/SolveConstraints.hs
+++ b/src/TypeInference/SolveConstraints.hs
@@ -356,11 +356,11 @@ subConstraints (SubType _ (TyCodata _ PosRep _ dtors1) (TyCodata _ NegRep _ dtor
 --     {{ Nat :>> < ctors1 > }} <: {{ Nat  :>> < ctors2 > }}   ~>    [ checkXtors ctors2 ctor | ctor <- ctors1 ]
 --     {{ Nat :>> < ctors1 > }} <: {{ Bool :>> < ctors2 > }}   ~>    FAIL
 --
-subConstraints (SubType _ (TyDataRefined _ PosRep _ tn1 _ ctors1) (TyDataRefined _ NegRep _ tn2 _ ctors2)) | tn1 == tn2 = do
+subConstraints (SubType _ (TyDataRefined _ PosRep _ tn1 ctors1) (TyDataRefined _ NegRep _ tn2 ctors2)) | tn1 == tn2 = do
   constraints <- forM ctors1 (checkXtor ctors2)
   pure (DataRefined tn1 $ SubVar . void <$> concat constraints, concat constraints)
 
-subConstraints (SubType _ (TyCodataRefined _ PosRep _ tn1 _ dtors1) (TyCodataRefined _ NegRep _ tn2 _ dtors2))  | tn1 == tn2 = do
+subConstraints (SubType _ (TyCodataRefined _ PosRep _ tn1 dtors1) (TyCodataRefined _ NegRep _ tn2 dtors2))  | tn1 == tn2 = do
   constraints <- forM dtors2 (checkXtor dtors1)
   pure (CodataRefined tn1 $ SubVar . void <$> concat constraints, concat constraints)
 


### PR DESCRIPTION
removes recvars from refinement types, but keeps the <Tyn|recvar|xtors> syntax, as recvars can only be inferred after the type automaton 